### PR TITLE
Non-default 'Surrounds' should include component id

### DIFF
--- a/perl_lib/EPrints/Plugin/InputForm/Surround/Light.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Surround/Light.pm
@@ -17,7 +17,10 @@ sub render
 	
 	my $content_class="";
 
-	my $surround = $self->{session}->make_element( "div", class => "ep_sr_component" );
+	my $surround = $self->{session}->make_element( "div", 
+		class => "ep_sr_component",
+		id => $component->{prefix} );
+
 	$surround->appendChild( $self->{session}->make_element( "a", name=>$component->{prefix} ) );
 	foreach my $field_id ( $component->get_fields_handled )
 	{

--- a/perl_lib/EPrints/Plugin/InputForm/Surround/None.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Surround/None.pm
@@ -15,7 +15,10 @@ sub render
 {
 	my( $self, $component ) = @_;
 
-	my $surround = $self->{session}->make_element( "div", class => "ep_sr_none" );
+	my $surround = $self->{session}->make_element( "div",
+		class => "ep_sr_none",
+		id => $component->{prefix} );
+
 	$surround->appendChild( $self->{session}->make_element( "a", name=>$component->{prefix} ) );
 	foreach my $field_id ( $component->get_fields_handled )
 	{


### PR DESCRIPTION
Otherwise Line 6 of 87_component_field.js:
```javascript
this.root = $(this.prefix); // == null
this.form = this.root.up ('form'); //generates uncaught error below
```
Error:
`Uncaught TypeError: Cannot read property 'up' of null`