### PR TITLE
Apply correct class when opening collapsed trees with JS

### DIFF
--- a/perl_lib/EPrints/XHTML.pm
+++ b/perl_lib/EPrints/XHTML.pm
@@ -875,7 +875,7 @@ sub tree
 	) );
 	$frag->appendChild( $repo->make_javascript(<<"EOJ") );
 Event.observe( window, 'load', function() {
-	ep_js_init_dl_tree('$opts{prefix}', '$opts{prefix}_open');
+	ep_js_init_dl_tree('$opts{prefix}', '$opts{class}_open');
 });
 EOJ
 


### PR DESCRIPTION
This PR fixes an issue where ep_js_init_dl_tree would add the wrong class to expanded dl tree elements. For example, a subject tree might be given the class "c32_tree_open" instead of the expected "ep_subjectinput_tree_open" (cf. subjectinput.css), meaning the associated icon would not change from plus to minus.