### PR TITLE
switch to utf8-output

### DIFF
--- a/perl_lib/EPrints/Plugin/Export.pm
+++ b/perl_lib/EPrints/Plugin/Export.pm
@@ -272,6 +272,7 @@ sub output_list
 		my $part = $plugin->output_dataobj( $item, %opts );
 		if( defined $opts{fh} )
 		{
+			binmode(STDOUT, ":utf8");
 			print {$opts{fh}} $part;
 		}
 		else


### PR DESCRIPTION
otherwise you could get some 'Wide character in print' for BibTeX-output