### PR TITLE
some new functions for ordering purpose added

### DIFF
--- a/lib/cfg.d/make_orderkey.pl
+++ b/lib/cfg.d/make_orderkey.pl
@@ -26,7 +26,7 @@ $c->{make_name_orderkey} = sub
 		my $name = $value->{$_};
 
 		# convert name appropriately
-		my $orderkey = ignoreExtras( $name );
+		my $orderkey = make_orderkey_ignore_extras( $name );
                 push  @orderkey, $orderkey;
          }
          return join( "_" ,  @orderkey );
@@ -39,7 +39,7 @@ $c->{make_title_orderkey} = sub
         $value =~ s/^[^a-z0-9]+//gi;
         if( $value =~ s/^(a|an|the) [^a-z0-9]*//i ) { $value .= ", $1"; }
 
-        return ignoreExtras($value);
+        return make_orderkey_ignore_extras($value);
 };
 
 $c->{make_value_orderkey} = sub
@@ -47,11 +47,11 @@ $c->{make_value_orderkey} = sub
 	my ($field, $value, $session, $langid, $dataset) = @_;
 
 	# convert name appropriately
-	my $orderkey = ignoreExtras( $value );
+	my $orderkey = make_orderkey_ignore_extras( $value );
 	return $orderkey;
 };
 
-sub ignoreExtras
+sub make_orderkey_ignore_extras
 {
 	my ($name) = @_;
 

--- a/lib/cfg.d/make_orderkey.pl
+++ b/lib/cfg.d/make_orderkey.pl
@@ -1,0 +1,67 @@
+######################################################################
+#
+# refering to http://threader.ecs.soton.ac.uk/lists/eprints_tech/1215.html, http://threader.ecs.soton.ac.uk/lists/eprints_tech/21544/attachment/default
+# as well as http://threader.ecs.soton.ac.uk/lists/eprints_tech/18088.html, i.e.
+# https://wiki.eprints.org/w/Category:EPrints_Metadata_Fields#Ordering.2C_Indexing_and_Searching
+# following functions
+# make_name_orderkey, make_title_orderkey, make_value_orderkey
+# manipulate the diacritics et al. for ordering purpose
+# to allow appropriate setting of make_value_orderkey or make_single_value_orderkey
+#
+######################################################################
+
+use Text::Unidecode;
+my $dbg = 0;
+
+$c->{make_name_orderkey} = sub
+{
+	my ($field, $value, $session, $langid, $dataset) = @_;
+
+ 	my  @orderkey;
+        foreach( "family", "given", "honourific" )
+        # foreach( "family", "lineage", "given", "honourific" )
+        {
+		next unless defined($value->{$_}) && $value->{$_} ne "";
+		print STDERR "field='", $_, ": " if $dbg;
+		my $name = $value->{$_};
+
+		# convert name appropriately
+		my $orderkey = ignoreExtras( $name );
+                push  @orderkey, $orderkey;
+         }
+         return join( "_" ,  @orderkey );
+};
+
+$c->{make_title_orderkey} = sub
+{
+        my( $field, $value, $dataset ) = @_;
+
+        $value =~ s/^[^a-z0-9]+//gi;
+        if( $value =~ s/^(a|an|the) [^a-z0-9]*//i ) { $value .= ", $1"; }
+
+        return ignoreExtras($value);
+};
+
+$c->{make_value_orderkey} = sub
+{
+	my ($field, $value, $session, $langid, $dataset) = @_;
+
+	# convert name appropriately
+	my $orderkey = ignoreExtras( $value );
+	return $orderkey;
+};
+
+sub ignoreExtras
+{
+	my ($name) = @_;
+
+	my  @orderkey;
+	# convert to upper case ASCII
+	my $orderkey = uc( unidecode( $name ) );
+	# keep separating dot (of initials from given name)
+	$orderkey =~ s/[\.]/_/g;
+	# ignore anything else than alphanumeric characters, aka non-word characters, except _
+	$orderkey =~ s/[^_A-Z0-9]//g;
+	print STDERR "name: '", $name, "', orderkey: '", $orderkey, "'\n" if $dbg;
+	return $orderkey;
+};

--- a/lib/cfg.d/make_orderkey.pl
+++ b/lib/cfg.d/make_orderkey.pl
@@ -42,7 +42,7 @@ $c->{make_title_orderkey} = sub
         return make_orderkey_ignore_extras($value);
 };
 
-$c->{make_value_orderkey} = sub
+$c->{make_sanitised_value_orderkey} = sub
 {
 	my ($field, $value, $session, $langid, $dataset) = @_;
 


### PR DESCRIPTION
do NOT forget to extend the appropriate metafield definition by
`make_single_value_orderkey => 'my_order_function'`
in order to solve [
Browse views ordering / grouping - problems with names with diacritics](https://github.com/eprints/eprints/issues/118)