### PR TITLE
Correction to allow epadmin create_db to work

### DIFF
--- a/perl_lib/EPrints/Database/mysql.pm
+++ b/perl_lib/EPrints/Database/mysql.pm
@@ -136,9 +136,11 @@ sub create
 
 	my $rc = 1;
 	
-	$rc &&= $dbh->do( "CREATE DATABASE IF NOT EXISTS ".$dbh->quote_identifier( $dbname )." DEFAULT CHARACTER SET ".$dbh->quote( $self->get_default_charset ) );
+        $rc &&= $dbh->do( "CREATE DATABASE IF NOT EXISTS ".$dbh->quote_identifier( $dbname )." DEFAULT CHARACTER SET ".$dbh->quote( $self->get_default_charset ) );
 
-	$rc &&= $dbh->do( "GRANT ALL PRIVILEGES ON ".$dbh->quote_identifier( $dbname ).".* TO ".$dbh->quote_identifier( $dbuser )."\@".$dbh->quote("localhost")." IDENTIFIED BY ".$dbh->quote( $dbpass ) );
+        $rc &&= $dbh->do( "CREATE USER ".$dbh->quote_identifier( $dbuser )."\@".$dbh->quote("localhost")." IDENTIFIED BY ".$dbh->quote( $dbpass ) );
+
+        $rc &&= $dbh->do( "GRANT ALL PRIVILEGES ON ".$dbh->quote_identifier( $dbname ).".* TO ".$dbh->quote_identifier( $dbuser )."\@".$dbh->quote("localhost") );
 
 	$dbh->disconnect;
 


### PR DESCRIPTION
When creating a database, the following error occurs:

Create database "test" [yes] ? 
Database Superuser Username [root] ? debian-sys-maint
Database Superuser Password? 
DBD::mysql::db do failed: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IDENTIFIED BY 'YeQPuV6p'' at line 1 at /usr/share/eprints/perl_lib/EPrints/Database/mysql.pm line 141, <STDIN> line 24.