### PR TITLE
Consider document security when adding to index

### DIFF
--- a/perl_lib/EPrints/MetaField/Subobject.pm
+++ b/perl_lib/EPrints/MetaField/Subobject.pm
@@ -276,6 +276,9 @@ sub get_index_codes_basic
 		}
 	}
 
+	# Allow indexcodes file to be generated, but don't add content to full-text index if the document isn't public.
+	return( [], [], [] ) unless $doc->exists_and_set( "security" ) && $doc->value( "security" ) eq "public";
+
 	return( [], [], [] ) unless defined $indexcodes_doc;
 
 	my $data = "";


### PR DESCRIPTION
Don't add full-text index terms if the document isn't public.