### PR TITLE
Fix syntax error in summary_page.xml

### DIFF
--- a/lib/citations/eprint/summary_page.xml
+++ b/lib/citations/eprint/summary_page.xml
@@ -33,7 +33,7 @@
             <td valign="top" align="right"><epc:print expr="$doc.icon('HoverPreview','noNewWindow')}" /></td>
             <td valign="top">
               <epc:print expr="$doc.citation('default')" /><br />
-              <a href="{$doc.url()}" class="ep_document_link"/><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
+              <a href="{$doc.url()}" class="ep_document_link"><epc:phrase ref="summary_page:download"/> (<epc:print expr="$doc.doc_size().human_filesize()" />)</a>
               <epc:if test="$doc.is_public()">
 			  <epc:choose>
 			  <epc:when test="$doc.thumbnail_url('video_mp4').is_set()">


### PR DESCRIPTION
Fixes error "Failed to parse XML file: /opt/eprints3/lib/citations/eprint/summary_page.xml: Entity: line 36: parser error : Opening and ending tag mismatch: td line 0 and a".