### PR TITLE
Make home link in default page template link to homepage

### DIFF
--- a/lib/templates/default.xml
+++ b/lib/templates/default.xml
@@ -16,7 +16,7 @@
           <nav aria-label="Main Navigation">
             <ul role="menu" class="ep_tm_menu">
               <li>
-                <a href="{$config{rel_path}}" title="{phrase('template/navigation:home:title')}" role="menuitem">
+                <a href="{$config{rel_path}}/" title="{phrase('template/navigation:home:title')}" role="menuitem">
                   <epc:phrase ref="template/navigation:home"/>
                 </a>
               </li>


### PR DESCRIPTION
This change ensures that when $config{rel_path} is the empty string (as it is on a fresh Zero flavour installation), the home page link resolves to the home page rather than the current page.