### PR TITLE
Remove flag for wrapping eprint results in table

### DIFF
--- a/lib/citations/eprint/result.xml
+++ b/lib/citations/eprint/result.xml
@@ -4,7 +4,7 @@
 	Neat citation for eprints used in search results.
 -->
 
-<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control" type="table_row">
+<cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
   <div class="ep_search_result">
     <div><epc:print expr="$n" />.</div>
     <div>


### PR DESCRIPTION
For accessibility, search results for eprints are now divs instead of tables. In a Zero repository, the `type="table-row"` attribute was still set, so rows would be wrapped erroneously in a table element. This change removes it, bringing it in line with pub_lib flavour version.