### PR TITLE
Re-enable support for compound non-multiple metafields

### DIFF
--- a/perl_lib/EPrints/MetaField/Compound.pm
+++ b/perl_lib/EPrints/MetaField/Compound.pm
@@ -125,13 +125,17 @@ sub render_value_actual
 		{
 			my $fieldname = $field_conf->{name};
 			(my $subfieldname = $fieldname) =~ s/^$self->{name}_//;
-                        if ( exists @{$value}[0]->{$subfieldname} || !$field_conf->{render_quiet} )
-                        {
-                                my $field = $self->{dataset}->get_field( $fieldname );
+			if (
+				   ( $self->get_property( "multiple" ) && exists @{$value}[0]->{$subfieldname} )
+				|| ( !$self->get_property( "multiple" ) && exists $value->{$subfieldname} )
+				|| !$field_conf->{render_quiet}
+			)
+			{
+				my $field = $self->{dataset}->get_field( $fieldname );
 				my $th = $session->make_element( "div", class=>"ep_compound_header_cell" );
-                                $tr->appendChild( $th );
-                                $th->appendChild( $field->render_name( $session ) );
-                        }
+				$tr->appendChild( $th );
+				$th->appendChild( $field->render_name( $session ) );
+			}
 		}
 	
 		if( $self->get_property( "multiple" ) )


### PR DESCRIPTION
If a field is defined as compound but not multiple, attempting to render the details for the item would trigger an error "Not an ARRAY reference at /opt/eprints3/perl_lib/EPrints/MetaField/Compound.pm line 128" since the value is dereferenced to an array (`@{$value}`) as a fix for issue #39.

This PR extends the fix so that it also works for non-multiple compound fields, where `$value` is a straightforward hashref.