### PR TITLE
In Listing plugin, complete change of ep_search_fields to div

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Listing.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Listing.pm
@@ -654,7 +654,7 @@ sub render_search_form
 	my $form = $self->render_form;
 	$form->setAttribute( method => "get" );
 
-	my $table = $self->{session}->make_element( "table", class=>"ep_search_fields" );
+	my $table = $self->{session}->make_element( "div", class=>"ep_search_fields" );
 	$form->appendChild( $table );
 
 	$table->appendChild( $self->render_search_fields );


### PR DESCRIPTION
Plugin::Screen::Listing::render_search_form() produces a table, the rows of which come from Plugin::Screen::Listing::render_search_fields(), which uses Repository::render_row_with_help(). This last function now outputs a `<div>` instead of a `<tr>` (for accessibility). Therefore the render_search_form() table should be implemented as a `<div>` instead of a `<table>`.