### PR TITLE
Generate message when max_items is reached for a view

### DIFF
--- a/perl_lib/EPrints/Update/Views.pm
+++ b/perl_lib/EPrints/Update/Views.pm
@@ -569,6 +569,12 @@ sub update_view_list
 	# hit the limit
 	if( $max_items && $count > $max_items )
 	{
+		$repo->log(
+			"Browse view $view->{id} ($target) contains more than $max_items items and has not been rendered.\n" .
+			"Consider creating sub-groupings for this view, increasing the 'max_items' value for this view " .
+			"or setting a 'browse_views_max_items' for the repository."
+		);
+
 		my $PAGE = $xml->create_element( "div",
 			class => "ep_view_page ep_view_page_view_$view->{id}"
 		);


### PR DESCRIPTION
If a view has more than 2,000 items (the default value) then a message is displayed on the browse view page (rather than the items).

This commit will generate a message in the error log when the _max_items_ value is reached for a view.


