### PR TITLE
'typos'/confusion removed in epadmin

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -561,7 +561,7 @@ That seemed to more or less work...
 Now make any required changes to the cfg files. 
 
 Note that changing the metadata configuration may require the database
-tables to be regenerated. epadmin erase_data will regenerate the 
+tables to be regenerated. epadmin erase_eprints will regenerate the 
 eprints and documents tables only. erase_data will regenerate everything.
 (nb. these also do erase the contents of the tables, and any uploaded 
 files).
@@ -574,7 +574,7 @@ Then stop and start your webserver:
 Often:
  /etc/rc.d/init.d/httpd stop
  /etc/rc.d/init.d/httpd start
-(or maybe /usr/local/apache/bin/apachectl stop & start)
+(or maybe /usr/local/apache/bin/apachectl graceful)
 
 And then try connecting to your repository.
 --------------------------------------------------------------------------


### PR DESCRIPTION
<code>graceful</code> restarts appropriately
on Debian:  /usr/sbin/apachectl