### PR TITLE
put key tool items into solid order

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/DataSets.pm
+++ b/perl_lib/EPrints/Plugin/Screen/DataSets.pm
@@ -18,7 +18,7 @@ sub new
 	$self->{appears} = [
 		{
 			place => "key_tools",
-			position => 150,
+			position => 1100,
 		}
 	];
 

--- a/perl_lib/EPrints/Plugin/Screen/Items.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Items.pm
@@ -22,7 +22,7 @@ sub new
 	$self->{appears} = [
 		{
 			place => "key_tools",
-			position => 100,
+			position => 175,
 		}
 	];
 


### PR DESCRIPTION
considering eprints/lib/cfg.d/dynamic_template.pl current doubling is avoided