### PR TITLE
Consider datestamp for deleted records when finding the earliest record

### DIFF
--- a/cgi/oai2
+++ b/cgi/oai2
@@ -412,7 +412,7 @@ sub Identify
 	);
 	$searchexp->add_field(
 		$dataset->field( "eprint_status" ),
-		"archive",
+		"archive deletion",
 		"EQ",
 		"ANY"
 	);


### PR DESCRIPTION
A deleted record may have a datestamp earlier than the earliest 'live' record.
This will cause the OAI-PMH validation to fail when a request is made for records before the `earliestDatestamp`, which returns earlier deleted records.

This change will make sure the datestamps of deleted records are also factored in to the `earliestDatestamp` element in the `Identify` response.