### PR TITLE
Add aria-labelledby and aria-describedby to Boolean menu

### DIFF
--- a/perl_lib/EPrints/MetaField/Boolean.pm
+++ b/perl_lib/EPrints/MetaField/Boolean.pm
@@ -108,6 +108,8 @@ sub get_basic_input_elements
 			default=>$value,
 			class=>join(" ", @classes),
 			onclick=>$onclick,
+			'aria-labelledby' => $self->get_labelledby( $basename ),
+			'aria-describedby' => $self->get_describedby( $basename, $one_field_component ),
 		);
 		return [[{ el=>$session->render_option_list( %settings ) }]];
 	}


### PR DESCRIPTION
This PR adds the aria-labelledby and aria-describedby attributes to option lists generated for Boolean fields where input_style is "menu".