### PR TITLE
Test email multiple recipients & add missing phrase

### DIFF
--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -3687,6 +3687,8 @@ PY = 2006 and OG = (Cambridge)<br />
 <epp:phrase id="Plugin/Screen/Admin/TestEmail:test_mail">This is an email sent by the administrator to confirm that EPrints email configuration is working as expected.</epp:phrase>
 <epp:phrase id="Plugin/Screen/Admin/TestEmail:send">Send</epp:phrase>
 <epp:phrase id="Plugin/Screen/Admin/TestEmail:mail_sent">Email successfully sent to <em><epc:pin name="requester"/></em>. It may take a few minutes for the email to arrive, depending on your local conditions.</epp:phrase>
+<epp:phrase id="Plugin/Screen/Admin/TestEmail:no_email"><p>Please supply at least one email address.</p></epp:phrase>
+<epp:phrase id="Plugin/Screen/Admin/TestEmail:mail_failed"><p>The system is currently unable to send email to <b><epc:pin name="requester" /></b>. Please check the email is correct and try again later. If this problem persists, please contact the <a href="mailto:{$config{adminemail}}">administrator</a> with details.</p></epp:phrase>
 
 <epp:phrase id="Plugin/Screen/Admin/Phrases:intro"><div>This tool writes modified phrases to zz_webcfg.xml. Click the phrase text to edit it. JavaScript required.</div></epp:phrase>
 <epp:phrase id="Plugin/Screen/Admin/Phrases:new_phrase">Add New Phrase</epp:phrase>


### PR DESCRIPTION
- FEATURE: Test email can now send email to one or many recipients.
- FIX: There is a missing phrase error when trying to send a test email without entering an email address