### PR TITLE
Fix DOI import error handling

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI.pm
@@ -102,19 +102,19 @@ sub input_text_fh
         $url->query_form( %params );
 
         my $dom_doc;
+        my $dom_top;
+        my $dom_query_result;
         eval {
             $dom_doc = EPrints::XML::parse_url( $url );
+            $dom_top = $dom_doc->getDocumentElement;
+            $dom_query_result = ($dom_top->getElementsByTagName( "query_result" ))[0];
         };
-
-        my $dom_top = $dom_doc->getDocumentElement;
-
-        my $dom_query_result = ($dom_top->getElementsByTagName( "query_result" ))[0];
 
         if( $@ || !defined $dom_query_result)
         {
             $plugin->handler->message( "warning", $plugin->html_phrase( "invalid_doi",
                 doi => $plugin->{session}->make_text( $doi ),
-                msg => $plugin->{session}->make_text( "No or unrecognised response" )
+                status => $plugin->{session}->make_text( "No or unrecognised response" )
             ));
             next;
         }
@@ -125,11 +125,9 @@ sub input_text_fh
 
         if( defined($status) && ($status eq "unresolved" || $status eq "malformed") )
         {
-            my $msg = ($dom_query->getElementsByTagName( "msg" ))[0];
-            $msg = EPrints::Utils::tree_to_utf8( $msg );
             $plugin->handler->message( "warning", $plugin->html_phrase( "invalid_doi",
                 doi => $plugin->{session}->make_text( $doi ),
-                msg => $plugin->{session}->make_text( $msg )
+                status => $plugin->{session}->make_text( $status )
             ));
             next;
         }

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI_UNIXREF.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI_UNIXREF.pm
@@ -103,17 +103,17 @@ sub input_text_fh
         $url->query_form( %params );
 
         my $dom_doc;
+        my $dom_crossref;
         eval {
             $dom_doc = EPrints::XML::parse_url( $url );
+            $dom_crossref = ($dom_doc->findnodes( "doi_records/doi_record/crossref" ))[0];
         };
-
-        my $dom_crossref = ($dom_doc->findnodes( "doi_records/doi_record/crossref" ))[0];
 
         if( $@ || !defined $dom_crossref)
         {
             $plugin->handler->message( "warning", $plugin->html_phrase( "invalid_doi",
                 doi => $plugin->{session}->make_text( $doi ),
-                msg => $plugin->{session}->make_text( "No or unrecognised response" )
+                status => $plugin->{session}->make_text( "No or unrecognised response" )
             ));
             next;
         }
@@ -124,7 +124,7 @@ sub input_text_fh
         {
             $plugin->handler->message( "warning", $plugin->html_phrase( "invalid_doi",
                 doi => $plugin->{session}->make_text( $doi ),
-                msg => $plugin->{session}->make_text( "error with DOI" )
+                status => $plugin->{session}->make_text( "error with DOI" )
             ));
             next;
         }

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -3314,7 +3314,7 @@ PY = 2006 and OG = (Cambridge)<br />
     <epp:phrase id="Plugin/Import/DefaultXML:unexpected_xml">Expected only text, found: <epc:pin name="xml" /></epp:phrase>
     <epp:phrase id="Plugin/Import/DefaultXML:file_imports_disabled">Attempt to import eprint with document data expressed as a local filename. This is a security hole in normal use, and is disabled. It *is* useful when bulk importing and may be enabled by setting enable_file_imports.</epp:phrase>
     <epp:phrase id="Plugin/Import/DefaultXML:file_not_exists">Could not locate file for import: <epc:pin name="href" />.</epp:phrase>
-    <epp:phrase id="Plugin/Import/DOI:invalid_doi">Unrecognised or invalid doi: <epc:pin name="doi" />.<br />Remote service said: <code><epc:pin name="msg"/></code></epp:phrase>
+    <epp:phrase id="Plugin/Import/DOI:invalid_doi">Unrecognised or invalid doi: <epc:pin name="doi" />.<br />Remote service status: <code><epc:pin name="status"/></code></epp:phrase>
     <epp:phrase id="Plugin/Import/DOI:duplicate_doi"><strong>Duplicate DOI: <epc:pin name="doi" /></strong>.<br />This DOI already exists in the repository: <br /><epc:pin name="msg"/></epp:phrase>
     <epp:phrase id="Plugin/Import/DOI_UNIXREF:invalid_doi" ref="Plugin/Import/DOI:invalid_doi"/>
     <epp:phrase id="Plugin/Import/DOI_UNIXREF:duplicate_doi" ref="Plugin/Import/DOI:duplicate_doi"/>


### PR DESCRIPTION
Fix for both flavours of DOI imports DOI.pm and DOI_UNIXREF.pm.

Issues: 
- Calling methods on undefined values.
- Getting element which does not exist. Crossrefs current documentation shows no sign of msg tag in the received xml.[1]

Fix: 
 - Wrapped running methods on possible undefined statements in prior eval statement.
 - Removed getElementsByTagName( "msg" ) statement and used the existing status tag.
 - Updated the phrase to accommodate for the status.

Tests:
- Tested to work with malformed, invalid and valid dois
```
10.1006/jmbi.1998.2354
doi:10.1055/s-0041-1734264
doi:10.1055/s.0041.1734264
10.1055/s.0041.1734264
10.1055
```

1. https://www.crossref.org/documentation/retrieve-metadata/xml-api/doi-to-metadata-query/