### PR TITLE
Split Time fields correctly when validating

### DIFF
--- a/perl_lib/EPrints/MetaField/Date.pm
+++ b/perl_lib/EPrints/MetaField/Date.pm
@@ -529,7 +529,7 @@ sub validate
 		return @probs if $resolution > 6;
 
 		$value = $self->trim_date( $value, $resolution );
-		my @date = split( /[-:]/, $value );
+		my @date = split( /[-: ]/, $value );
 
 		return @probs if scalar( @date ) != $resolution;
 		foreach ( @date )


### PR DESCRIPTION
The time format EPrints uses is ‘yyyy-mm-dd hh:MM:ss’, so splitting on `/[-:]/` alone means the day component comes out as ‘dd hh’.

This commit ensures the components are split on spaces as well, so the day and hour are properly separated.