### PR TITLE
Add ability to manipulate element attributes

### DIFF
--- a/lib/cfg.d/build_attributes.pl
+++ b/lib/cfg.d/build_attributes.pl
@@ -38,7 +38,6 @@
 #
 ######################################################################
 
-=pod
 $c->{build_node_attributes} = sub
 {
 	my ($repo, $name, $node, @attrs) = @_;
@@ -56,7 +55,7 @@ $c->{build_node_attributes} = sub
 	for my $key_in ( keys %attrs_in )
 	{
 		my $value_in = $attrs_in{$key_in};
-		if ( defined $value_in && $value_in ne "" )
+		if ( EPrints::Utils::is_set( $value_in ) )
 		{
 			for my $value_in_single ( split(" ", $value_in) )
 			{
@@ -64,12 +63,12 @@ $c->{build_node_attributes} = sub
 				if ( defined $attrs_config )
 				{
 					for ( @$attrs_config )
-					{				
+					{
 						my %attr_config = %$_;
 						for my $key_config ( keys %attr_config )
 						{
 							my $value_config = resolve_value( $repo, $attr_config{$key_config} );
-							if ( exists $attrs_in{$key_config} && $attr_config{_change_action} eq "add" )
+							if ( exists $attrs_in{$key_config} && EPrints::Utils::is_set( $attr_config{_change_action} ) && $attr_config{_change_action} eq "add" )
 							{
 								$attrs_in{$key_config} = $attrs_in{$key_config}." ".$value_config;
 							}
@@ -87,7 +86,6 @@ $c->{build_node_attributes} = sub
 	@attrs = %attrs_in;
 	return @attrs;
 };
-=cut
 
 =head1 COPYRIGHT
 

--- a/lib/cfg.d/build_attributes.pl
+++ b/lib/cfg.d/build_attributes.pl
@@ -1,0 +1,128 @@
+######################################################################
+#
+#  Manipulate attributes for create_element
+#
+###################################################################### 
+#
+# An example subroutine for maniputlating attributes before elements are created
+# This function is called from perl_lib/EPrints/XML.pm sub create_element if present in config
+#
+# The function example below will allow for attributes to be manipulated with the following structure
+#       1. Look for the attribute value in config i.e. $c
+#       2. Apply any changes to that specific value i.e. either replace or add to it
+#       3. If there are multiple attribute values it will cycle through them and repeat the above
+#       4. Finally it will add any extra attributes that are found within the config hash
+#
+# Examples:
+# - A class addition, useful for adding framework css classes
+#       $c->{config_class}->{"ep_something"} = { _class => "new-class", _action => "add" };
+#
+# - A change to the elements id attribute, useful for overwriting layered css
+#       $c->{config_id}->{"ep_phraseedit_addbar"} = { _id => "my_new_id", _change_action => "replace" };
+#
+# - Adding a new data attribute, useful for addding in accessibility attributes
+#       $c->{config_class}->{"ep_inaccessibile"} = { data-accessibility => "value" };
+#
+# - Creating a classname based on user account type
+#	$c->{config_class}->{"ep_page_thing"} = { _class => sub {
+#                                        my $repo = shift @_;
+#
+#                                        if ( defined $repo->current_user && $repo->current_user->is_staff )
+#                                        {
+#                                                return "staff-member-class";
+#                                        }
+#                                        else
+#                                        {
+#                                                return "non-staff-class";
+#                                        }
+#                                },
+#                                _change_action => "replace" };
+#
+######################################################################
+
+=pod
+$c->{build_node_attributes} = sub
+{
+        my ($repo, $name, $node, @attrs) = @_;
+
+        my @new_attrs = ();
+
+	sub resolve_value {
+		my ( $repo, $val ) = @_;
+
+		return( 0 ) if( !defined $val );
+
+		ref( $val ) eq "CODE" ? return $val->( $repo ) : return $val;
+	}
+
+        while(my( $key, $value ) = splice(@attrs,0,2))
+        {
+		if ( defined $value && $value ne "" )
+		{
+                        my $build_value = "";
+                        for my $core_value ( split(" ", $value) )
+                        {
+                                my $config_attribute = $repo->config( "config_$key", $core_value );
+                                if ( defined $config_attribute->{"_$key"} )
+                                {
+					my $resolved_value = resolve_value( $repo, $config_attribute->{"_$key"} );
+                                        if ( $config_attribute->{_change_action} eq "replace" )
+                                        {
+                                                $core_value = $resolved_value;
+                                        }
+                                        elsif ( $config_attribute->{_change_action} eq "add" )
+                                        {
+                                                $core_value = $core_value." ".$resolved_value;
+                                        }
+                                }
+                                $build_value = $build_value." ".$core_value;
+
+                                # Any extra attributes in the config should be added here	
+                                while( my( $config_key, $config_value ) = each %$config_attribute )
+                                {
+					$config_value = resolve_value( $config_value );
+                                        push @new_attrs, ( $config_key, $config_value ) if !( $config_key =~ m/^_{1}/ );
+                                }
+                        }
+                        $build_value =~ s/^\s{1}//;
+			push @new_attrs, ( $key, $build_value );
+		}
+		else
+		{
+			push @new_attrs, ( $key, $value );
+		}
+        }
+
+        return @new_attrs;
+};
+=cut
+
+=head1 COPYRIGHT
+
+=for COPYRIGHT BEGIN
+
+Copyright 2022 University of Southampton.
+EPrints 3.4 is supplied by EPrints Services.
+
+http://www.eprints.org/eprints-3.4/
+
+=for COPYRIGHT END
+
+=for LICENSE BEGIN
+
+This file is part of EPrints 3.4 L<http://www.eprints.org/>.
+
+EPrints 3.4 and this file are released under the terms of the
+GNU Lesser General Public License version 3 as published by
+the Free Software Foundation unless otherwise stated.
+
+EPrints 3.4 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with EPrints 3.4.
+If not, see L<http://www.gnu.org/licenses/>.
+
+=for LICENSE END

--- a/lib/cfg.d/build_attributes.pl
+++ b/lib/cfg.d/build_attributes.pl
@@ -80,7 +80,7 @@ $c->{build_node_attributes} = sub
                                 # Any extra attributes in the config should be added here	
                                 while( my( $config_key, $config_value ) = each %$config_attribute )
                                 {
-					$config_value = resolve_value( $config_value );
+					$config_value = resolve_value( $repo, $config_value );
                                         push @new_attrs, ( $config_key, $config_value ) if !( $config_key =~ m/^_{1}/ );
                                 }
                         }

--- a/lib/cfg.d/build_attributes.pl
+++ b/lib/cfg.d/build_attributes.pl
@@ -67,6 +67,8 @@ $c->{build_node_attributes} = sub
 						my %attr_config = %$_;
 						for my $key_config ( keys %attr_config )
 						{
+							next if ( $key_config =~ m/^_{1}/ );
+
 							my $value_config = resolve_value( $repo, $attr_config{$key_config} );
 							if ( exists $attrs_in{$key_config} && EPrints::Utils::is_set( $attr_config{_change_action} ) && $attr_config{_change_action} eq "add" )
 							{

--- a/perl_lib/EPrints/XML.pm
+++ b/perl_lib/EPrints/XML.pm
@@ -180,9 +180,9 @@ sub create_element
 	my $repo = $self->{repository};
 	my $node = $self->{doc}->createElement( $name );
 
-        if ( defined $repo && $repo->can_call( "build_node_attributes" ) ){
-                @attrs = $repo->call( "build_node_attributes", $repo, $name, $node, @attrs );
-        }
+	if ( defined $repo && $repo->can_call( "build_node_attributes" ) ){
+		@attrs = $repo->call( "build_node_attributes", $repo, $name, $node, @attrs );
+	}
 
 	while(my( $key, $value ) = splice(@attrs,0,2))
 	{

--- a/perl_lib/EPrints/XML.pm
+++ b/perl_lib/EPrints/XML.pm
@@ -177,7 +177,13 @@ sub create_element
 {
 	my( $self, $name, @attrs ) = @_;
 
+	my $repo = $self->{repository};
 	my $node = $self->{doc}->createElement( $name );
+
+        if ( defined $repo && $repo->can_call( "build_node_attributes" ) ){
+                @attrs = $repo->call( "build_node_attributes", $repo, $name, $node, @attrs );
+        }
+
 	while(my( $key, $value ) = splice(@attrs,0,2))
 	{
 		next if !defined $value;


### PR DESCRIPTION
### Adding the ability to make attributes and their values more configurable. 
`perl_lib/EPrints/XML.pm`
- If a config level routine is present use it to process element attributes

`lib/cfg.d/build_attributes.pl`
- An example which provides the ability to add, change and conditionally add attributes and their values

As is, this function will not be called and will therefore will not break any current repository which upgrades to a version containing this change.