### PR TITLE
Add classnames to navigation items and links

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen.pm
+++ b/perl_lib/EPrints/Plugin/Screen.pm
@@ -387,7 +387,8 @@ sub render_action_link
 		screen => substr($self->{id},8),
 	);
 
-	my $link = $self->{session}->render_link( $uri );
+	$opts{class} = "ep_tm_key_tools_item_link" if not defined $opts{class}; 
+	my $link = $self->{session}->render_link( $uri, undef, %opts );
 	$link->appendChild( $self->render_title );
 
 	return $link;

--- a/perl_lib/EPrints/Plugin/Screen/Admin/Config/Edit/XPage.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Admin/Config/Edit/XPage.pm
@@ -51,7 +51,7 @@ sub action_edit {} # dummy action for key_tools
 
 sub render_action_link
 {
-	my( $self ) = @_;
+	my( $self, %opts ) = @_;
 
 	my $conffile = $self->{processor}->{conffile};
 
@@ -61,7 +61,8 @@ sub render_action_link
 		configfile => $conffile,
 	);
 
-	my $link = $self->{session}->render_link( $uri );
+	$opts{class} = "ep_tm_key_tools_item_link" if not defined $opts{class};
+	my $link = $self->{session}->render_link( $uri, undef, %opts );
 	$link->appendChild( $self->{session}->html_phrase( "lib/session:edit_page" ) );
 
 	return $link;

--- a/perl_lib/EPrints/Plugin/Screen/Admin/Phrases.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Admin/Phrases.pm
@@ -326,7 +326,7 @@ sub redirect_to_me_url
 
 sub render_action_link
 {
-	my( $self ) = @_;
+	my( $self, %opts ) = @_;
 
 	my $uri = $self->{session}->current_url(
 			scheme => "https",
@@ -338,7 +338,8 @@ sub render_action_link
 		edit_phrases => "yes"
 	);
 
-	my $link = $self->{session}->render_link( $uri );
+        $opts{class} = defined $opts{class} ? $opts{class} : "ep_tm_key_tools_item_link";
+	my $link = $self->{session}->render_link( $uri, undef, %opts );
 	$link->appendChild(
 		$self->{session}->html_phrase( "lib/session:edit_phrases" )
 	);

--- a/perl_lib/EPrints/Plugin/Screen/Register.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Register.pm
@@ -74,7 +74,8 @@ sub render_action_link
 	my $repo = $self->{session};
 
 	my $link = $repo->xml->create_element( "a",
-		href => $repo->config( "http_cgiroot" ) . "/register"
+		href => $repo->config( "http_cgiroot" ) . "/register",
+		class => "ep_tm_key_tools_item_link"
 	);
 	$link->appendChild( $self->render_title );
 

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -3375,12 +3375,13 @@ it needs to point to a different frame or window.
 
 sub render_link
 {
-	my( $self, $uri, $target ) = @_;
+	my( $self, $uri, $target, %opts ) = @_;
 
 	return $self->make_element(
 		"a",
 		href=>$uri,
-		target=>$target );
+		target=>$target,
+		%opts );
 }
 
 ######################################################################

--- a/perl_lib/EPrints/ScreenProcessor.pm
+++ b/perl_lib/EPrints/ScreenProcessor.pm
@@ -248,7 +248,7 @@ sub render_item_list
 	{
 		my $screen = $opt->{screen};
 
-		my $li = $xml->create_element( "li" );
+		my $li = $xml->create_element( "li", class => "ep_tm_key_tools_item" );
 
 		my $li_class = "";
                 $li_class = $self->{session}->config( 'item_list_class' ) if defined $self->{session}->config( 'item_list_class' );


### PR DESCRIPTION
Adding class attributes to the main ep_tools navigation items.
```HTML
<li>
    <a href="/cgi/users/home?screen=Items">Manage deposits</a>
</li>
```
Becomes...
```HTML
<li class="ep_tm_key_tools_item">
    <a href="/cgi/users/home?screen=Items" class="ep_tm_key_tools_item_link">Manage deposits</a>
</li>
```

- Allows for easier styling and attribute replacement via `lib/cfg.d/build_attributes.pl`