### PR TITLE
ejo clean empty cite key and import, then report

### DIFF
--- a/flavours/pub_lib/plugins/BibTeX/Parser/Entry.pm
+++ b/flavours/pub_lib/plugins/BibTeX/Parser/Entry.pm
@@ -48,7 +48,7 @@ sub error {
 		$self->{_error} = shift;
 		$self->parse_ok(0);
 	}
-	return $self->parse_ok ? undef : $self->{_error};
+	return defined $self->{_error} ? $self->{_error} : undef;
 }
 
 

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Import/BibTeX.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Import/BibTeX.pm
@@ -271,11 +271,9 @@ sub input_text_fh
 	
 	while(my $entry = $parser->next)
 	{
-		if( !$entry->parse_ok )
-		{
-			$plugin->warning( "Error parsing: " . $entry->error );
-			next;
-		}
+
+		$plugin->warning( "Error parsing: " . $entry->error ) if defined $entry->error;
+		next if !$entry->parse_ok;
 
 		my $epdata = $plugin->convert_input( $entry );
 		next unless defined $epdata;


### PR DESCRIPTION
fixes #273 

This fix raises an error and still imports, when there is an empty citekey. As suggested on #273.

When parsing a BibTex entry the empty CiteKey is removed if empty or contains only whitespace, so this...
```BibTex
@inproceedings { ,
```
or this...
```BibTex
@inproceedings {,
```

Becomes...
```BibTex
@inproceedings {
```

This is achieved within the `flavours/pub_lib/plugins/BibTeX/Parser.pm` file. A match is made and a flag is raised. 
```perl
            # Remove empty CiteKey
            if ($line =~ m/{\s*,/){
                $line =~ s/{\s*,/{/;
                $emptyCiteKeyRemoved = 1;
            }
```
Then once the entry is completely parsed we raise the error if no other issues are found. `parse_ok` is still set to true as we can still import the file.
```perl
$current_entry->error("Malformed entry (key contains no characters, skipping key)") if $emptyCiteKeyRemoved;
$current_entry->parse_ok(1);
```

To successfully raise an error and still import that entry, the `sub error` function needs to be decoupled from `parse_ok` attribute. Making them independent gives BibTex Import more control over when to display errors that are permissible. 

`flavours/pub_lib/plugins/BibTeX/Parser/Entry.pm`
```perl 
-	return $self->parse_ok ? undef : $self->{_error};
+	return defined $self->{_error} ? $self->{_error} : undef;
```

Finally, when looping over entries in `flavours/pub_lib/plugins/EPrints/Plugin/Import/BibTeX.pm` the entry can both have an error raised and be imported. But the entry will never be imported if the parse is not ok, regardless of an empty cite key.
```perl
		$plugin->warning( "Error parsing: " . $entry->error ) if defined $entry->error;
		next if !$entry->parse_ok;
```