### PR TITLE
Render search help icons using create_element, not a phrase, allowing…

### DIFF
--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -1703,8 +1703,12 @@ For more information see <a href="http://eprints.org/d/?keyword=MetaFields">Meta
     <epp:phrase id="lib/session:error_title">Error</epp:phrase>
     <epp:phrase id="lib/session:no_login">You are somehow accessing a page which requires you to be logged in, without actually being logged in. This probably indicates a server misconfiguration.</epp:phrase>
     <epp:phrase id="lib/session:no_priv">You do not have the required privilege to use this function.</epp:phrase>
-    <epp:phrase id="lib/session:show_help"><epc:pin name="link"><img alt="+" title="Show help" src="{$config{rel_path}}/style/images/help.png" border="0"/></epc:pin></epp:phrase>
-    <epp:phrase id="lib/session:hide_help"><epc:pin name="link"><img alt="-" title="Hide help" src="{$config{rel_path}}/style/images/minus.png" border="0"/></epc:pin></epp:phrase>
+    <epp:phrase id="lib/session:hide_help_title">Hide help</epp:phrase>
+    <epp:phrase id="lib/session:hide_help_alt">-</epp:phrase>
+    <epp:phrase id="lib/session:hide_help_src">/style/images/minus.png</epp:phrase>
+    <epp:phrase id="lib/session:show_help_title">Show help</epp:phrase>
+    <epp:phrase id="lib/session:show_help_alt">+</epp:phrase>
+    <epp:phrase id="lib/session:show_help_src">/style/images/help.png</epp:phrase>
 
     <epp:phrase id="lib/session:edit_page">Edit page</epp:phrase>
     <epp:phrase id="lib/session:edit_phrases">Edit page phrases</epp:phrase>

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -3527,12 +3527,14 @@ sub render_row_with_help
 	my $td2 = $self->make_element( "div", class=>"ep_multi_help ep_only_js_table_cell ep_toggle ep_table_cell" );
 	my $show_help = $self->make_element( "div", class=>"ep_sr_show_help ep_only_js", id=>$parts{help_prefix}."_show" );
 	my $helplink = $self->make_element( "a", onclick => "EPJS_blur(event); EPJS_toggleSlide('$parts{help_prefix}',false,'block');EPJS_toggle('$parts{help_prefix}_hide',false,'block');EPJS_toggle('$parts{help_prefix}_show',true,'block');return false", href=>"#" );
-	$show_help->appendChild( $self->html_phrase( "lib/session:show_help",link=>$helplink ) );
+	$helplink->appendChild( $self->make_element( "img", alt => "+", title=> "Show help", src => "/style/images/plus.png" ) );
+	$show_help->appendChild( $helplink );
 	$td2->appendChild( $show_help );
 
 	my $hide_help = $self->make_element( "div", class=>"ep_sr_hide_help ep_hide", id=>$parts{help_prefix}."_hide" );
 	my $helplink2 = $self->make_element( "a", onclick => "EPJS_blur(event); EPJS_toggleSlide('$parts{help_prefix}',false,'block');EPJS_toggle('$parts{help_prefix}_hide',false,'block');EPJS_toggle('$parts{help_prefix}_show',true,'block');return false", href=>"#" );
-	$hide_help->appendChild( $self->html_phrase( "lib/session:hide_help",link=>$helplink2 ) );
+        $helplink2->appendChild( $self->make_element( "img", alt => "-", title=> "Hide help", src => "/style/images/minus.png" ) );
+	$hide_help->appendChild( $helplink2 );
 	$td2->appendChild( $hide_help );
 	$tr->appendChild( $td2 );
 

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -3527,13 +3527,19 @@ sub render_row_with_help
 	my $td2 = $self->make_element( "div", class=>"ep_multi_help ep_only_js_table_cell ep_toggle ep_table_cell" );
 	my $show_help = $self->make_element( "div", class=>"ep_sr_show_help ep_only_js", id=>$parts{help_prefix}."_show" );
 	my $helplink = $self->make_element( "a", onclick => "EPJS_blur(event); EPJS_toggleSlide('$parts{help_prefix}',false,'block');EPJS_toggle('$parts{help_prefix}_hide',false,'block');EPJS_toggle('$parts{help_prefix}_show',true,'block');return false", href=>"#" );
-	$helplink->appendChild( $self->make_element( "img", alt => "+", title=> "Show help", src => "/style/images/plus.png" ) );
+	$helplink->appendChild( $self->make_element( "img", 
+		alt => $self->html_phrase( "lib/session:show_help_alt" ), 
+		title=> $self->html_phrase( "lib/session:show_help_title" ), 
+		src => $self->html_phrase( "lib/session:show_help_src" ) ) );
 	$show_help->appendChild( $helplink );
 	$td2->appendChild( $show_help );
 
 	my $hide_help = $self->make_element( "div", class=>"ep_sr_hide_help ep_hide", id=>$parts{help_prefix}."_hide" );
 	my $helplink2 = $self->make_element( "a", onclick => "EPJS_blur(event); EPJS_toggleSlide('$parts{help_prefix}',false,'block');EPJS_toggle('$parts{help_prefix}_hide',false,'block');EPJS_toggle('$parts{help_prefix}_show',true,'block');return false", href=>"#" );
-        $helplink2->appendChild( $self->make_element( "img", alt => "-", title=> "Hide help", src => "/style/images/minus.png" ) );
+        $helplink2->appendChild( $self->make_element( "img", 
+		alt => $self->html_phrase( "lib/session:hide_help_alt" ), 
+		title=> $self->html_phrase( "lib/session:hide_help_title" ), 
+		src => $self->html_phrase( "lib/session:hide_help_src" ) ) );
 	$hide_help->appendChild( $helplink2 );
 	$td2->appendChild( $hide_help );
 	$tr->appendChild( $td2 );


### PR DESCRIPTION
… build attributes to manipulate

Instead of using the lib phrase to render the (open and close) help icon, use the make element function which passes over build attributes if it exists and allows attribute manipulation. 