### PR TITLE
Additional classes and ids

### DIFF
--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -2458,7 +2458,7 @@ Views
     <epp:phrase id="Update/Views:no_grouping_title">Nothing</epp:phrase>
     <epp:phrase id="Update/Views:jump_to"><div class="ep_view_jump_to">Jump to: <epc:pin name="jumps" /></div></epp:phrase>
 	<epp:phrase id="Update/Views:jump_separator"> | </epp:phrase>
-    <epp:phrase id="Update/Views:up_a_level"><div class="no_link_decor"><epc:pin name="url"><img src="{$config{rel_path}}/style/images/multi_up.png" alt="[up]" border='0' /> Up a level</epc:pin></div></epp:phrase>
+    <epp:phrase id="Update/Views:up_a_level"> Up a level</epp:phrase>
     <epp:phrase id="Update/Views:no_items"><p>No items in this section.</p></epp:phrase>
     <epp:phrase id="Update/Views:no_value">NULL</epp:phrase>
     <epp:phrase id="Update/Views:export_section">

--- a/perl_lib/EPrints/Plugin/InputForm/Component/Documents.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Component/Documents.pm
@@ -595,9 +595,14 @@ sub _render_doc_metadata
 		my $labeltext = $field->render_name($session);
 		if( $field->{required} ) # moj: Handle for_archive
 		{
-			$labeltext = $self->{session}->html_phrase( 
-				"sys:ep_form_required",
-				label=>$labeltext );
+			my $required = $self->{session}->make_element( "img",
+				src => "/style/images/required.png",
+				border => "0",
+				class => "ep_required",
+				alt => "Required",
+				style=>"display: inline" );
+			$required->appendChild( $labeltext );
+			$labeltext = $required;
 		}
 		$no_toggle = 1 if $field->{show_help} eq "always";
 		$no_toggle = 0 if $field->{show_help} eq "toggle";

--- a/perl_lib/EPrints/Plugin/InputForm/Component/Field/Multi.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Component/Field/Multi.pm
@@ -161,9 +161,13 @@ sub render_content
 		if( $field->{required} ) # moj: Handle for_archive
 		{
 			my $label = $self->{session}->make_element( "span", id => $self->{prefix}."_".$field->get_name."_label" );
-			my $labeltext = $self->{session}->html_phrase(
-                                "sys:ep_form_required",
-                                label=>$parts{label} );
+			my $labeltext = $self->{session}->make_element( "img", 
+				src => "/style/images/required.png",
+				border => "0",
+				class => "ep_required",
+				alt => "Required",
+				style=>"display: inline" );
+			$labeltext->appendChild( $self->{session}->make_text( $parts{label} ));
 			$label->appendChild( $labeltext );
 			$parts{label} = $label;
 		}

--- a/perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm
@@ -19,9 +19,14 @@ sub render_title
 
 	if( $component->is_required )
 	{
-		$title = $self->{session}->html_phrase( 
-			"sys:ep_form_required",
-			label=>$title );
+		my $required = $self->{session}->make_element("img", 
+			src=>"/style/images/required.png", 
+			border=>"0", 
+			class=>"ep_required", 
+			alt=>"Required", 
+			style=>"display: inline" );
+		$required->appendChild( $title );
+		$title = $required;
 	}
 
 	return $title;
@@ -174,7 +179,12 @@ sub _render_help
 		my $link = $session->make_element( "a",
 			onclick => $jscript,
 			href => '#' );
-		$div->appendChild( $self->html_phrase( "${action}_help", link => $link ) );
+		$link->appendChild( $session->make_element( "img", 
+			alt => "+", 
+			title => "${action} help", 
+			src => $action eq "show" ? "/style/images/help.png" : "/style/images/minus.png", 
+			border => "0" ));
+		$div->appendChild( $link );
 
 		$action_div->appendChild( $div );
 	}

--- a/perl_lib/EPrints/Plugin/Screen.pm
+++ b/perl_lib/EPrints/Plugin/Screen.pm
@@ -581,7 +581,7 @@ sub render_action_list_icons
 		push @actions, $self->render_action_icon( { %$params, hidden => $hidden } );
 	}
 
-	return $repo->xhtml->action_list( \@actions );
+	return $repo->xhtml->action_list( \@actions, id => $list_id );
 }
 
 1;

--- a/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/File.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/File.pm
@@ -243,6 +243,7 @@ sub render
 	$container->appendChild( $xml->create_element( "input",
 		name => $ffname,
 		id => $ffname,
+		class => "ep_upload_button",
 		type => "file",
 		onchange => "UploadMethod_file_change(this,'$self->{parent}->{prefix}','$self->{prefix}')",
 		) );

--- a/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/URL.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/URL.pm
@@ -76,6 +76,7 @@ sub render
 		name => $ffname,
 		size => "30",
 		id => $ffname,
+		class => "ep_upload_url_input"
 		);
 	my $add_format_button = $self->{session}->render_button(
 		value => $self->{session}->phrase( "Plugin/InputForm/Component/Upload:add_format" ), 

--- a/perl_lib/EPrints/Plugin/Screen/Items.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Items.pm
@@ -251,9 +251,7 @@ sub render_items
 		my %q = $self->hidden_bits;
 		$q{"set_show_$f"} = !$filters{$f};
 		$url->query_form( %q );
-		my $link = $session->render_link( $url );
-		# http://servicesjira.eprints.org:8080/browse/RCA-175
-		$link->setAttribute( 'class', "ep_items_filters_$f" );
+		my $link = $session->render_link( $url, "", class => "ep_items_filter ep_items_filters_$f" );
 		if( $filters{$f} )
 		{
 			$link->appendChild( $session->make_element(

--- a/perl_lib/EPrints/XHTML.pm
+++ b/perl_lib/EPrints/XHTML.pm
@@ -814,7 +814,7 @@ sub tabs
 		my $width = int( 100 / @$labels );
 		$width += 100 % @$labels if $_ == 0;
 		my $tab = $ul->appendChild( $xml->create_element( "li",
-			($current == $_ ? (class => "ep_tab_selected") : ()),
+			($current == $_ ? (class => "ep_tab_selected") : (class => "ep_tab_not_selected")),
 			id => $basename."_tab_".$sanit_label,
 			role => "tab",
 			style => "width: $width\%",
@@ -971,7 +971,7 @@ sub action_list
 	my $repo = $self->{repository};
 	my $xml = $repo->xml;
 
-	my $ul = $xml->create_element( "ul", class => "ep_action_list", role => "toolbar" );
+	my $ul = $xml->create_element( "ul", class => "ep_action_list", role => "toolbar", %opts );
 	for(@$actions)
 	{
 		$ul->appendChild( $xml->create_data_element( "li", $_ ) );


### PR DESCRIPTION
 For use generally and to be taken advantage of by the new bootstrap5 ingredient.

`lib/lang/en/phrases/system.xml` 
`perl_lib/EPrints/Plugin/InputForm/Component/Documents.pm` 
`perl_lib/EPrints/Plugin/InputForm/Component/Field/Multi.pm`
`perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm`
Renders link within plugin, not phrase.

`perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm`
Render image within plugin, not phase.

`perl_lib/EPrints/Plugin/Screen.pm`
Add ID attribute.

`perl_lib/EPrints/Plugin/Screen/Items.pm`
Generic filter class.

`perl_lib/EPrints/XHTML.pm`
Add class specific to non selected items and allow action lists to render class names.
