### PR TITLE
Minor changes to EPrints::Extras and EPrints::XML

### DIFF
--- a/perl_lib/EPrints/Extras.pm
+++ b/perl_lib/EPrints/Extras.pm
@@ -56,12 +56,8 @@ sub render_xhtml_field
 	my( $session , $field , $value ) = @_;
 
 	if( !defined $value ) { return $session->make_doc_fragment; }
-        my( %c ) = (
-                ParseParamEnt => 0,
-                ErrorContext => 2,
-                NoLWP => 1 );
 
-		local $SIG{__DIE__};
+	local $SIG{__DIE__};
         my $doc = eval { EPrints::XML::parse_xml_string( "<fragment>".$value."</fragment>" ); };
         if( $@ )
         {

--- a/perl_lib/EPrints/XML.pm
+++ b/perl_lib/EPrints/XML.pm
@@ -20,8 +20,8 @@ B<EPrints::XML> - XML Abstraction Module
 
 	my $xml = $repository->xml;
 
-	$doc = $xml->parse_string( $string );
-	$doc = $xml->parse_file( $filename );
+	$doc = $xml->parse_string( $string, %opts );
+	$doc = $xml->parse_file( $filename, %opts );
 	$doc = $xml->parse_url( $url );
 
 	$utf8_string = $xml->to_string( $dom_node, %opts );
@@ -147,7 +147,7 @@ sub parse_file
 	return parse_xml( $filename, $opts{base_path}, $opts{no_expand} );
 }
 
-=item $doc = $xml->parse_url( $url, %opts )
+=item $doc = $xml->parse_url( $url )
 
 Returns an XML document parsed from the content located at $url.
 


### PR DESCRIPTION
Removes redundant code from `EPrints::Extras` and also corrects some POD in `EPrints::XML`.

Fixes #313 