### PR TITLE
Align headings when Itemref occurs within Compound Metafield

### DIFF
--- a/perl_lib/EPrints/MetaField/Compound.pm
+++ b/perl_lib/EPrints/MetaField/Compound.pm
@@ -490,7 +490,7 @@ sub get_input_col_titles
 	foreach my $field ( @{$f} )
 	{
 		my $fieldname = $field->get_name;
-		my $sub_r = $field->get_input_col_titles( $session, $staff );
+		my $sub_r = $field->get_input_col_titles( $session, $staff, 1 );
 
 		if( !defined $sub_r )
 		{

--- a/perl_lib/EPrints/MetaField/Itemref.pm
+++ b/perl_lib/EPrints/MetaField/Itemref.pm
@@ -49,6 +49,20 @@ sub get_property_defaults
 	return %defaults;
 }
 
+sub get_input_col_titles
+{
+	my ( $self, $session, $staff, $from_compound ) = @_;
+	if ( !$from_compound )
+	{
+		return;
+	}
+
+	my @r;
+	push @r, $self->render_name($session);
+	push @r, $session->make_doc_fragment();
+	return \@r;
+}
+
 sub get_basic_input_elements
 {
 	my( $self, $session, $value, $basename, $staff, $obj, $one_field_component ) = @_;
@@ -60,6 +74,18 @@ sub get_basic_input_elements
 	push @{$ex->[0]}, {el=>$desc, style=>"padding: 0 0.5em 0 0.5em;"};
 
 	return $ex;
+}
+
+sub get_basic_input_ids
+{
+	my ( $self, $session, $basename, $staff, $obj, $from_compound ) = @_;
+	my @r;
+	push @r, $basename;
+	if ($from_compound)
+	{
+		push @r, $basename . '_citation';
+	}
+	return @r;
 }
 
 sub render_single_value


### PR DESCRIPTION
When an Itemref Metafield occurs within a Compound Metafield, it adds two elements to the Compound Metafield's `get_basic_input_elements` array of input elements, but only one element to its `get_basic_input_ids` and `get_input_col_titles` arrays. This means that subsequent column headings end up out of alignment with the respective input elements.

![itemref_before](https://github.com/eprints/eprints3.4/assets/1890395/8db90d87-3286-4e02-b91a-d31c28c9825f)

This PR seeks to add an additional column heading in this circumstance without causing headings to appear when the Itemref is rendered individually. Result:

![itemref_after](https://github.com/eprints/eprints3.4/assets/1890395/65e517b3-f6e9-45e1-bc40-bda04fbe7fca)
