### PR TITLE
Ejo redo thumbnails update

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -1564,9 +1564,10 @@ sub redo_thumbnails
 			print "Redoing thumbnails for document ".$doc->id."\n";
 		}
 
-		$doc->remove_thumbnails; #ouch!
+
 		if ( $doc->parent )
 		{
+			$doc->remove_thumbnails; #ouch!
 			$doc->make_thumbnails;
 		}
 		else

--- a/bin/epadmin
+++ b/bin/epadmin
@@ -1564,7 +1564,6 @@ sub redo_thumbnails
 			print "Redoing thumbnails for document ".$doc->id."\n";
 		}
 
-
 		if ( $doc->parent )
 		{
 			$doc->remove_thumbnails; #ouch!

--- a/bin/epadmin
+++ b/bin/epadmin
@@ -1565,7 +1565,14 @@ sub redo_thumbnails
 		}
 
 		$doc->remove_thumbnails; #ouch!
-		$doc->make_thumbnails;
+		if ( $doc->parent )
+		{
+			$doc->make_thumbnails;
+		}
+		else
+		{
+			print STDERR "No such eprint for document '".$doc->id."'\n";
+		}
 	};
 
 	my $dataset = $repo->dataset( "document" );


### PR DESCRIPTION
It has been observed that documents can have no parent eprint. This should not stop you from being able to redo_thumbnails on the whole dataset. Especially when the parents existence is checked for when providing a list of ID's to redo_thumbnails.