### PR TITLE
Encode field values sent in autocompleter requests

### DIFF
--- a/lib/static/javascript/auto/70_autocomplete.js
+++ b/lib/static/javascript/auto/70_autocomplete.js
@@ -18,7 +18,7 @@ function ep_autocompleter( element, target, url, basenames, width_of_these, fiel
       $(target+"_loading").style.width  = w + 'px';
 
       var params = fields_to_send.inject( entry, function( acc, rel_id, index ) { 
-        return acc + '&' + rel_id + '=' + $F(basenames.relative + rel_id); } );
+        return acc + '&' + rel_id + '=' + encodeURIComponent($F(basenames.relative + rel_id)); } );
       return params + extra_params;
     },
     paramName: 'q',


### PR DESCRIPTION
When autocompleting a compound field, the parameters sent include the value of the active field and the values of all the component fields. Currently, the value of the active field is URI-encoded but the other values are not. Let's say the creators field has an affiliation subfield:

```
q=Example%20College%3B%20University
&name_family=Smith
&name_given=Sam
&affiliation=Example College; University
```

This is normally harmless since few characters cause issues in this context and unescaping occurs before the values reach the processing script. However, in CGI.pm v2.64+, the semicolon is treated as an alias for ampersand and therefore terminates the value. This means when using `$session->param` we get

```
q => 'Example%20College%3B%20University',
affiliation => 'Example College'
```

This PR applies URI encoding to the field values added by the `ep_autocompleter` callback so they are handled equivalently to the `q` parameter.