### PR TITLE
Remove references to review_fields

### DIFF
--- a/lib/cfg.d/user_fields_default.pl
+++ b/lib/cfg.d/user_fields_default.pl
@@ -5,9 +5,8 @@ $c->{set_user_defaults} = sub
 
 	$data->{hideemail} = "TRUE";
 
-	# Default columns shown in Items and Editorial Review screens
+	# Default columns shown in Items screens
 	$data->{items_fields} = [ "lastmod", "title", "type", "eprint_status" ];
-	$data->{review_fields} = [ "status_changed", "title", "type", "userid" ];
 };
 
 =head1 COPYRIGHT

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -4020,9 +4020,6 @@ PY = 2006 and OG = (Cambridge)<br />
     <epp:phrase id="user_fieldname_items_fields"><epc:phrase ref="Plugin/Screen/Items:title" /> Fields</epp:phrase>
     <epp:phrase id="user_fieldhelp_items_fields">The fields shown for each item on the <epc:phrase ref="Plugin/Screen/Items:title" /> page.</epp:phrase>
 
-    <epp:phrase id="user_fieldname_review_fields"><epc:phrase ref="Plugin/Screen/Review:title" /> Fields</epp:phrase>
-    <epp:phrase id="user_fieldhelp_review_fields">The fields shown for each item on the <epc:phrase ref="Plugin/Screen/Review:title" /> page.</epp:phrase>
-
     <epp:phrase id="user_typename_minuser">Minimal User</epp:phrase>
     <epp:phrase id="user_typename_user">User</epp:phrase>
     <epp:phrase id="user_typename_editor">Editor</epp:phrase>


### PR DESCRIPTION
Fixes #401 

Code also reviewed for 'items_fields', which _is_ still a field of the user object, so doesn't need addressing.