### PR TITLE
Make parsing of robots.txt more resilient

### DIFF
--- a/perl_lib/EPrints/Apache/RobotsTxt.pm
+++ b/perl_lib/EPrints/Apache/RobotsTxt.pm
@@ -81,12 +81,13 @@ END
 	my @lines = split( '\n', $robots );
 	my $lineno = 0;
 	my $default_ua_config = "";
-	while ( lc( $lines[$lineno] ) !~ /user-agent: \*/ )
+	while ( lc( $lines[$lineno] // q() ) !~ /user-agent: \*/ )
 	{
 		$lineno++;
+  		last if $lineno >= @lines;
 	}
 	$lineno++;
-	while ( $lines[$lineno] !~ /^\s*$/ )
+	while ( ( $lines[$lineno] // q() ) !~ /^\s*$/ )
 	{
 		$default_ua_config .= $lines[$lineno] ."\n";
 		$lineno++;


### PR DESCRIPTION
The code for parsing robots.txt introduced in commit 336f693 can run into problems if the content is not in the right form:

- If the file is empty, so too will be `@lines`, so `lc` will throw an uninitialized value warning at line 84.
- If the file does not contain a "User-agent: *" line, the code will get stuck in an infinite loop.
- If the file does not contain blank line after "User-agent: *", the pattern match at line 89 will throw an uninitialized value warning when the loop terminates.

These problems are resolved in this commit.