### PR TITLE
Update Recaptcha3 to work with non-request workflows e.g. registration

### DIFF
--- a/perl_lib/EPrints/MetaField/Recaptcha3.pm
+++ b/perl_lib/EPrints/MetaField/Recaptcha3.pm
@@ -59,7 +59,6 @@ sub get_property_defaults
 {
         my( $self ) = @_;
         my %defaults = $self->SUPER::get_property_defaults;
-        $defaults{action} = "request";
 
         return %defaults;
 }
@@ -90,12 +89,6 @@ sub render_input_field_actual
 		id => "g-recaptcha-response",
 		name => "g-recaptcha-response",
 	) );
-
-	$frag->appendChild( $session->make_element( "input",
-		type => "hidden",
-		name => "_action_" . $self->get_property( "action" ),
-		value => "1",
-	) ); 
 
 	$frag->appendChild( $session->make_javascript( <<EOJ ) );
 	function sleep(ms) {

--- a/perl_lib/EPrints/Plugin/Screen/Public/RequestCopy.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Public/RequestCopy.pm
@@ -330,6 +330,8 @@ sub render
 
 	$form->appendChild( $self->workflow->render );
 
+	$form->appendChild( $session->render_hidden_field( "_default_action", "request" ) );
+
 	$form->appendChild( $session->xhtml->action_button(
 			request => $session->phrase( "request:button" )
 		) );


### PR DESCRIPTION
When trying to use the recaptcha3 on a registration form, the action that is called is `_action_request` - which doesn't exist as an action in the Registration module.

Moving the hidden action field aligns with the existing Registration code: https://github.com/eprints/eprints3.4/blob/806f2da7a0cdd543d57fcf237964d98efe43b08e/perl_lib/EPrints/Plugin/Screen/Register.pm#L229