### PR TITLE
Apply subtitle to book_title for book chapter items

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Import/DOI.pm
@@ -340,6 +340,11 @@ sub content_item
 	{
 		$data->{type} = "book_section";
 		$data->{volume_title} = $data->{title};
+                if( defined( $data->{subtitle} ) )
+                {
+                        $data->{volume_title} .= ": ".$data->{subtitle};
+                        $data->{subtitle} = undef;
+                }
 	}
 	$plugin->item_metadata( $data, $node );	
 }


### PR DESCRIPTION
Book subtitle is being included with the Chapter title in error.

If subtitle defined when setting book title during chapter import then apply the subtitle to the book title and clear it from the subtitle data field rather than leave it to be applied to the chapter.