### PR TITLE
Prototype CVE - update prototype.js

### DIFF
--- a/ingredients/prototypejs/static/javascript/auto/20_prototype.js
+++ b/ingredients/prototypejs/static/javascript/auto/20_prototype.js
@@ -621,7 +621,7 @@ Object.extend(String.prototype, (function() {
   }
 
   function stripTags() {
-    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>'"])+)?\s*("[^">]*|'[^'>])?(\/)?>|<\/\w+>/gi, '');
+    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>'"])+)?\s*("[^">]*|'[^'>]*)?(\/)?>|<\/\w+>/gi, '');
   }
 
   function stripScripts() {

--- a/ingredients/prototypejs/static/javascript/auto/20_prototype.js
+++ b/ingredients/prototypejs/static/javascript/auto/20_prototype.js
@@ -8,7 +8,7 @@
 
 var Prototype = {
 
-  Version: '1.7.3',
+  Version: '1.7.3-eprints',
 
   Browser: (function(){
     var ua = navigator.userAgent;
@@ -621,7 +621,7 @@ Object.extend(String.prototype, (function() {
   }
 
   function stripTags() {
-    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>])+)?(\/)?>|<\/\w+>/gi, '');
+    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>'"])+)?\s*("[^">]*|'[^'>])?(\/)?>|<\/\w+>/gi, '');
   }
 
   function stripScripts() {

--- a/ingredients/prototypejs/static/javascript/auto/20_prototype.js
+++ b/ingredients/prototypejs/static/javascript/auto/20_prototype.js
@@ -8,7 +8,7 @@
 
 var Prototype = {
 
-  Version: '1.7.3-eprints',
+  Version: '1.7.3.1-eprints',
 
   Browser: (function(){
     var ua = navigator.userAgent;


### PR DESCRIPTION
Prototype is not being developed/released any more, but there is a fix for the CVE detailed in: https://github.com/prototypejs/prototype/pull/349

I don't think that this CVE is 'dangerous' in relation to the regular EPrints codebase, but it does get flagged by scanning services.
The version string `1.7.3.1-eprints` has been invented for our purposes. It is used by prototype when constructing XMLHttpRequest headers.

NB There are also other things that were committed to the [prototype master branch since the 1.7.3 release](https://github.com/prototypejs/prototype/compare/1.7.3...master), but I don't think it's worth doing anything with these, as EPrints will not rely on Prototype in the future.


