### PR TITLE
Implement missing triggers EP_TRIGGER_BEGIN and EP_TRIGGER_END

### DIFF
--- a/perl_lib/EPrints/Const.pm
+++ b/perl_lib/EPrints/Const.pm
@@ -124,6 +124,8 @@ Continue normal processing.
 
 =item EP_TRIGGER_BEGIN
 
+Called immediately after the 'session_init' config method (see archive config or lib/cfg.d/session.pl). These triggers should not set a return value, so all of them can run. Could be used to pre-cache information in the session, or other 'expensive' tasks that should run once.
+
 =item EP_TRIGGER_BEGIN_REQUEST
 
 Called after L<EPrints::Repository/init_from_request>.
@@ -133,6 +135,8 @@ Called after L<EPrints::Repository/init_from_request>.
 Called just before L<EPrints::Repository/cleanup> in response to a mod_perl request.
 
 =item EP_TRIGGER_END
+
+Called immediately before the 'session_close' config method (see archive config or lib/cfg.d/session.pl). These triggers should not set a return value, so the whole stack can run.
 
 =item EP_TRIGGER_URL_REWRITE
 

--- a/perl_lib/EPrints/Const.pm
+++ b/perl_lib/EPrints/Const.pm
@@ -153,6 +153,13 @@ Called for every request that is within the repository's path. Use this to redir
 
 =item EP_TRIGGER_DOC_URL_REWRITE
 
+Similar to the EP_TRIGGER_URL_REWRITE trigger, but is active when the request is for a document. Can be used to return variant versions of a document. It has the following additional parameters passed to it:
+
+	eprint - EPrint object that owns the requested document
+	document - Document object being requested
+	filename - Filename - initially taken from end of the URI
+	relations - if the document position path in the URL has digits followed by a '.', this is the rest of that path component, split on '.'s  e.g. hassmallThumbnailVersion
+
 =item EP_TRIGGER_CREATED
 
 Called after $dataset->create_dataobj( { ... } ).

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -222,6 +222,7 @@ sub new
 	}
 
 	$self->call( "session_init", $self, $self->{offline} );
+	$self->run_trigger( EP_TRIGGER_BEGIN, offline => $self->{offline} );
 
 	$self->{loadtime} = time();
 	
@@ -507,6 +508,7 @@ sub terminate
 {
 	my( $self ) = @_;
 	
+	$self->run_trigger( EP_TRIGGER_END );
 	$self->call( "session_close", $self );
 
 	if( $self->{noise} >= 2 ) { print "Ending EPrints Repository.\n\n"; }


### PR DESCRIPTION
These two triggers are defined in the EPrints::Const module, but are never actually called anywhere.

I believe they would have been conceived to perform a similar role to the `session_init` and `session_close` configuration methods (default methods are in `~/lib/cfg.d/session.pl`).

Part of a solution to #427 could have used `EP_TRIGGER_BEGIN` to cache database information e.g. column lengths or charsets.

It is worth noting that the `~/bin/epadmin` script is missing some '$repo->terminate()` calls, so the existing `session_close` and the new `EP_TRIGGER_END` wouldn't get called. Once example of this is the `test` command.

This section of the wiki: page: https://wiki.eprints.org/w/Triggers#EP_TRIGGER_BEGIN would need to be updated if/when this has been merged.

The following examples could be added to the above page, or included in an example file:
```perl
use EPrints::Const;

# This has the repo and 'online' flag passed in
$c->add_trigger( EP_TRIGGER_BEGIN, sub {
        my %params = @_;
        my $repo = $params{repository};
        my $online = $params{online}; #is this session web-based

        #... do stuff
}, priority => 100 );

# This only has the repo passed in
$c->add_trigger( EP_TRIGGER_END, sub {
        my %params = @_;
        my $repo = $params{repository};

        #... do other stuff
}, priority => 100 );

```