### PR TITLE
Make document thumbnails use long URL format

### DIFF
--- a/perl_lib/EPrints/DataObj/Document.pm
+++ b/perl_lib/EPrints/DataObj/Document.pm
@@ -1853,6 +1853,7 @@ sub thumbnail_url
 			"^A-Za-z0-9\-\._~\/"
 		);
 	}
+	$path = "id/eprint/$path" if $self->{session}->get_conf( "use_long_url_format" );
 
 	return $self->{session}->current_url(
 		host => 1,


### PR DESCRIPTION
Currently `$doc->thumbnail_url` returns a value based on `$doc->path`, which in turn is based on `$eprint->path`.

The `path` methods don't take `use_long_url_format` into consideration, so still produce an `eprintid/doc-pos/` style URL. 
This fix will produce the correct long format when needed.

The short style of URL is handled with a redirect in `EPrints::Apache::Rewrite`, so they still appear to work, but it's a needless redirect.