### PR TITLE
Align basic-auth in Sword and Auth modules

### DIFF
--- a/perl_lib/EPrints/Apache/Sword.pm
+++ b/perl_lib/EPrints/Apache/Sword.pm
@@ -81,22 +81,16 @@ sub authenticate
                 return \%response;
         }
 
-        my $username;
-        my $password;
+	my ( $username, $password ) = split /:/, $authorization, 2;
 
-	if($decode_authen =~ /^(\w+)\:(\w+)$/)
-        {
-                $username = $1;
-                $password = $2;
-        }
-        else
+	if( !defined $username || !defined $password )
         {
                 $response{error} = {
                                         status_code => 401,
                                         x_error_code => "ErrorAuth",
                                         error_href => "http://eprints.org/sword/error/ErrorAuth",
                                    };
-                $response{verbose_desc} .= "[ERROR] Authentication failed (invalid base64 encoding).\n";
+                $response{verbose_desc} .= "[ERROR] Authentication failed (username or password not sent).\n";
                 return \%response;
         }
 

--- a/perl_lib/EPrints/Apache/Sword.pm
+++ b/perl_lib/EPrints/Apache/Sword.pm
@@ -81,7 +81,7 @@ sub authenticate
                 return \%response;
         }
 
-	my ( $username, $password ) = split /:/, $authorization, 2;
+	my ( $username, $password ) = split /:/, $decode_authen, 2;
 
 	if( !defined $username || !defined $password )
         {


### PR DESCRIPTION
The previous regex in the Sword module would fail for passwords that contained non-word characters.

NB this would also have impacted the Pure / PDA module here: https://github.com/eprints/pure_connector/blob/main/plugins/PDA/PDAHandler.pm#L42

There is still a difference in the surrounding code: 
- EPrints::Apache::Auth::auth_basic does this: `my $authorization = $r->headers_in->{'Authorization'};`
- EPrints::Apache::Sword::authenticate does: `my $authen = EPrints::Apache::AnApache::header_in( $request, 'Authorization' );`

I couldn't work out whether these could/should be normalised too, but they're not broken unlike the regex that has been replaced.