### PR TITLE
More tweaks to cache

### DIFF
--- a/flavours/pub_lib/defaultcfg/cfg.d/citationcaches.pl
+++ b/flavours/pub_lib/defaultcfg/cfg.d/citationcaches.pl
@@ -7,6 +7,7 @@ $c->{datasets}->{citationcache} = {
 $c->{citation_caching}->{enabled} = 0;
 $c->{citation_caching}->{excluded_dataobjs} = [
 	'epm',
+	'eventqueue',
 	'loginticket',
 	'subject',
 ];

--- a/lib/defaultcfg_zero/cfg.d/citationcaches.pl
+++ b/lib/defaultcfg_zero/cfg.d/citationcaches.pl
@@ -7,6 +7,7 @@ $c->{datasets}->{citationcache} = {
 $c->{citation_caching}->{enabled} = 0;
 $c->{citation_caching}->{excluded_dataobjs} = [
 	'epm',
+	'eventqueue',
 	'loginticket',
 	'subject',
 ];

--- a/perl_lib/EPrints/DataObj.pm
+++ b/perl_lib/EPrints/DataObj.pm
@@ -1588,7 +1588,7 @@ sub render_citation
 	my $citation_caching_enabled = 0;
 	if ( !defined $params{no_cache} || !$params{no_cache} )
 	{
-		my @excluded_dataobjs = ( 'epm', 'loginticket', 'subject' );
+		my @excluded_dataobjs = ( 'epm', 'eventqueue', 'loginticket', 'subject' );
 		my @excluded_styles = ( 'result' );
 		@excluded_dataobjs = @{$self->{session}->config( "citation_caching", "excluded_dataobjs" )} if defined $self->{session}->config( "citation_caching", "excluded_dataobjs" );
 		@excluded_styles = @{$self->{session}->config( "citation_caching", "excluded_styles" )} if defined $self->{session}->config( "citation_caching", "excluded_styles" );

--- a/perl_lib/EPrints/DataObj.pm
+++ b/perl_lib/EPrints/DataObj.pm
@@ -813,6 +813,9 @@ sub remove
 
 	$self->queue_removed;
 
+	# clean-up citation cache for this item
+	$self->clear_citationcaches() if defined $self->{session}->config( "citation_caching", "enabled" ) && $self->{session}->config( "citation_caching", "enabled" ) && $self->{dataset}->confid ne "citationcache";
+
 	return $self->{session}->get_database->remove(
 		$self->{dataset},
 		$self->get_id );

--- a/perl_lib/EPrints/DataObj/User.pm
+++ b/perl_lib/EPrints/DataObj/User.pm
@@ -875,6 +875,9 @@ sub remove
 		$saved_search->remove;
 	}
 
+	# clean-up citation cache for this item
+	$self->clear_citationcaches() if defined $self->{session}->config( "citation_caching", "enabled" ) && $self->{session}->config( "citation_caching", "enabled" ) && $self->{dataset}->confid ne "citationcache";
+
 	# remove user record
 	my $user_ds = $self->{session}->get_repository->get_dataset( "user" );
 	$success = $success && $self->{session}->get_database->remove(


### PR DESCRIPTION
A couple of updates:
- removal of cache entries when dataobj is removed (the User dataobj doesn't call the 'SUPER' method, but other dataobjs do, if they overload `remove`).
- exclude eventqueue citations from being cached
 
Most DataObjs use a `counter` type field for their id, and the citation cache expects the objectid to be numeric.
The event queue uses UUIDs for it's id field, which will be truncated if the citation is sent to the cache table.
This was observed during a `~/bin/indexer debug` run:
`[ARCHIVEID] Error committing citationcache.658012: Incorrect integer value: 'a43a80c6b5c3fbf1a08d37e86deadfa1' for column `ARCHIVEID`.`citationcache`.`objectid` at row 1

