### PR TITLE
Allow custom sort to be applied at a browse menu level

### DIFF
--- a/lib/defaultcfg_zero/cfg.d/views.pl
+++ b/lib/defaultcfg_zero/cfg.d/views.pl
@@ -98,7 +98,27 @@ $c->{browse_views} = [
 # Browse by the type of eprint (poster, report etc).
 #{ id=>"type", menus=>[ { fields=>"type" } ], order=>"-date" }
 
-
+# Use a default sort order e.g. for number stored in text fields
+#	{
+#		id => "journal_volume",
+#		menus => [
+#			{
+#				fields => [ "publication" ],  # First level: Journals
+#				hideempty => 1,  # Hide journals with no articles
+#			},
+#			{
+#				fields => [ "volume" ],
+#				hideempty => 1,
+#				sort_order => sub {
+#					my( $repo, $values, $lang ) = @_;
+#					my @sorted_values = sort { $a <=> $b } @$values; ## Use numeric sorting method
+#
+#					return \@sorted_values;
+#				},
+#			},
+#		],
+#		order => "-date/title",
+#	},
 
 
 

--- a/perl_lib/EPrints/Update/Views.pm
+++ b/perl_lib/EPrints/Update/Views.pm
@@ -115,6 +115,12 @@ Don't show a link to this view from the /view/ page.
 
 =item reverse_order = 0
 
+=item sort_order = sub { ... }
+
+Allows the default ordering (from EPrints::Metafield) to be replaced with a custom order. This
+may be useful for numbers-stored-as-text. The sub should return an array ref. See the 'journal_volume'
+example in lib/defaultcfg_zero/cfg.d/views.pl.
+
 =item mode = "default"
 
 Use "sections" to cause the menu to be broken into sections.
@@ -424,8 +430,15 @@ sub update_view_menu
 	# translate ids to values
 	my @values = map { $menu_fields->[0]->get_value_from_id( $repo, $_ ) } keys %$sizes;
 
-	# OK now we have a sorted list of values....
-	@values = @{$menu_fields->[0]->sort_values( $repo, \@values, $langid )};
+	# OK now we want to sort the list of values....
+	if( defined $menu->{sort_order} )
+	{
+		@values = @{ &{$menu->{sort_order}}( $repo, \@values, $langid ) };
+	}
+	else
+	{
+		@values = @{$menu_fields->[0]->sort_values( $repo, \@values, $langid )};
+	}
 
 	if( $menu->{reverse_order} )
 	{


### PR DESCRIPTION
Fixes #461 

An example view based on the default test data set:
```perl
{
    id => "journal_volume",
    menus => [
        {
            fields => [ "publication" ],
            hideempty => 1,
        },
        {
            fields => [ "volume" ],
            hideempty => 1,
            sort_order => sub {
                my( $repo, $values, $lang ) = @_;
                my @sorted_values = sort { $a <=> $b } @$values;

                return \@sorted_values;
            },
        },
    ],
},
```

