### PR TITLE
Fix lightbox popup preview of a video

### DIFF
--- a/ingredients/prototypejs/static/javascript/auto/40_lightbox.js
+++ b/ingredients/prototypejs/static/javascript/auto/40_lightbox.js
@@ -602,9 +602,6 @@ Lightbox.prototype = {
 		link.setAttribute( 'href', src );
 		link.setAttribute( 'style', 'display: block; width: ' + width + 'px; height: ' + height + 'px' );
 		html5.appendChild( link );
-		flowplayer( link, eprints_http_root + '/flowplayer-3.2.1.swf' );
-
-		//this.lightboxMovie.appendChild( video );
 		this.lightboxMovie.update( html5 );
 
 		this.resizeImageContainer(width, height);


### PR DESCRIPTION
We don't have the source code of flowplayer, so it produces an error and then the lightbox breaks. Just removing this results in a working video player.