### PR TITLE
Make 'Move' positions unique

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/EPrint/Move.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/Move.pm
@@ -27,7 +27,7 @@ sub new
 { place => "eprint_editor_actions", 	action => "move_deletion", 	position => 700, },
 { place => "eprint_actions_bar_buffer", action => "move_archive", position => 100, },
 { place => "eprint_actions_bar_archive", action => "move_buffer", position => 100, },
-{ place => "eprint_actions_bar_archive", action => "move_deletion", position => 100, },
+{ place => "eprint_actions_bar_archive", action => "move_deletion", position => 110, },
 { place => "eprint_actions_bar_deletion", action => "move_archive", position => 100, },
 { place => "eprint_review_actions", action => "move_archive", position => 200, },
 	];


### PR DESCRIPTION
Two actions with same position in same action list don't have reliable ordering.