### PR TITLE
Retain attribute order in build_attributes

### DIFF
--- a/lib/cfg.d/build_attributes.pl
+++ b/lib/cfg.d/build_attributes.pl
@@ -44,6 +44,8 @@ $c->{build_node_attributes} = sub
 
 	my ($repo, $name, $node, @attrs) = @_;
 
+	return @attrs unless defined $repo->config( "config_attrs" );
+ 
 	my %attrs_in = @attrs;
 
 	sub resolve_value {
@@ -87,8 +89,23 @@ $c->{build_node_attributes} = sub
 		}
 	}
 
-	@attrs = %attrs_in;
-	return @attrs;
+	# step through original array of keys/vals and
+	for( my $i = 0; $i < scalar @attrs; $i +=2 )
+	{
+		if( defined $attrs_in{$attrs[$i]} )
+		{
+			@attrs[$i+1] = $attrs_in{$attrs[$i]};
+			#remove element - so we can append any additional keys to the end below
+			delete $attrs_in{$attrs[$i]};
+		}
+	}
+	# add any remaining values, in a normalised order
+	for my $k ( sort keys %attrs_in )
+	{
+		push @attrs, $k, $attrs_in{$k};
+	}
+
+ 	return @attrs;
 };
 
 =head1 COPYRIGHT


### PR DESCRIPTION
NB Updated PR - forgot to rebase branch first

Fixes #483 by splicing values back into the original array.

Also returns quicker (line 47) if config hash is not defined.

Tested with the following config (not sure if this is exhaustive):
```perl
push @{$c->{config_attrs}->{class}->{"ep_tm_menu_tools"}}, ({ class => "framework-class", _change_action => "replace" });
push @{$c->{config_attrs}->{class}->{"ep_tm_key_tools_item_link"}}, ({ class => "framework-class", _change_action => "add" });
push @{$c->{config_attrs}->{id}->{"ep_tm_menu_browse"}}, ({ id => "new_id", _change_action => "replace" });
push @{$c->{config_attrs}->{id}->{"ep_tm_menu_tools"}}, ({ "data_info" => "data-info" });
push @{$c->{config_attrs}->{id}->{"ep_tm_menu_tools"}}, ({ "wibble" => "wobble" });
push @{$c->{config_attrs}->{class}->{"ep_tm_key_tools"}}, ({ class => sub {
                        my $repo = shift @_;
                        if ( defined $repo->current_user && $repo->current_user->is_staff )
                        {
                                return "staff-member-class";
                        }
                        else
                        {
                                return "non-staff-class";
                        }
                }, _change_action => "add" });
```