### PR TITLE
Implements #465 by adding uuid field to Cachemap

### DIFF
--- a/perl_lib/EPrints/DataObj/Cachemap.pm
+++ b/perl_lib/EPrints/DataObj/Cachemap.pm
@@ -49,6 +49,11 @@ DEPRECATED. A boolean to record whether the cache is for single use
 where it will be created, used and immediately deleted.  Such as 
 type of caching is no longer required.
 
+=item uuid (uuid)
+
+a uuid to uniquely identify a cache table entry, which is less
+guessable than an auto-ncrementing number.
+
 =back
 
 =head1 REFERENCES AND RELATED OBJECTS
@@ -172,6 +177,8 @@ sub get_system_field_info
 		{ name=>"searchexp", type=>"longtext", required=>0, text_index=>0 },
 
 		{ name=>"oneshot", type=>"boolean", required=>0, text_index=>0 },
+
+		{ name=>"uuid", type=>"uuid", required=>0, text_index=>0 },
 	);
 }
 
@@ -367,6 +374,28 @@ sub create_sql_table
 			]);
 
 	return $rc;
+}
+
+######################################################################
+=pod
+
+=item $id = $cachemap->get_uuid
+
+Gets the C<uuid> or the cachemap if set otherwise returns the 
+auto-incremented C<cachemapid>.
+
+=cut
+######################################################################
+
+sub get_uuid
+{
+    my( $self ) = @_;
+
+	if ( $self->get_value( 'uuid' ) )
+	{
+		return  $self->get_value( 'uuid' );
+	}
+	return $self->get_id;
 }
 
 1;

--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -2007,14 +2007,11 @@ sub cache_exp
 	my( $self , $id ) = @_;
 
 	my $a = $self->{session}->get_repository;
-
 	my $cache = $self->get_cachemap( $id );
 
 	return unless $cache;
 
 	my $created = $cache->get_value( "created" );
-	my $cache_maxlife = $a->get_conf("cache_maxlife") * 3600;
-
 	if( (time() - $created) > ($a->get_conf("cache_maxlife") * 3600) )
 	{
 		return;

--- a/perl_lib/EPrints/List.pm
+++ b/perl_lib/EPrints/List.pm
@@ -467,8 +467,8 @@ sub count
 	{
 		#cjg Should really have a way to get at the
 		# cache. Maybe we should have a table object.
-		return $self->{session}->get_database->count_table(
-			"cache".$self->{cache_id} );
+		my $cachemap = $self->{session}->get_database->get_cachemap( $self->{cache_id} );
+		return $self->{session}->get_database->count_table( $cachemap->get_sql_table_name );
 	}
 
 	EPrints::abort( "Called \$list->count() where there was no cache or ids." );

--- a/perl_lib/EPrints/Search.pm
+++ b/perl_lib/EPrints/Search.pm
@@ -71,8 +71,6 @@ See L<EPrints::List> for more.
 
 package EPrints::Search;
 
-use Digest::MD5;
-use Time::HiRes;
 use URI::Escape;
 use strict;
 
@@ -1088,6 +1086,7 @@ sub perform_search
 		);
 	}
 
+
 	# print STDERR $self->get_conditions->describe."\n\n";
 
 	my $cachemap;
@@ -1097,19 +1096,11 @@ sub perform_search
 		my $userid = $self->{session}->current_user;
 		$userid = $userid->get_id if defined $userid;
 
-		my $lastused = Time::HiRes::time;
-
-		my $md5 = Digest::MD5->new;
-		$md5->add( $lastused );
-		$md5->add( $userid );
-		$md5->add( $self->serialise );
-
 		$cachemap = $self->{session}->get_repository->get_dataset( "cachemap" )->create_object( $self->{session}, {
-			lastused => $lastused,
+			lastused => time(),
 			userid => $userid,
 			searchexp => $self->serialise,
 			oneshot => "TRUE",
-			uuid => $md5->hexdigest,
 		} );
 		$cachemap->create_sql_table( $self->{dataset} );
 	}


### PR DESCRIPTION
Will force use of uuid if set but will support legacy cachemap entries that only have a cachemapid set.