### PR TITLE
Implements #476 by customisably showing text links for untitled subjects

### DIFF
--- a/perl_lib/EPrints/DataObj/Subject.pm
+++ b/perl_lib/EPrints/DataObj/Subject.pm
@@ -873,8 +873,12 @@ This is an alias for:
 
 sub render_description
 {
-	my( $self ) = @_;
+	my( $self, $use_citation ) = @_;
 
+	if ( $use_citation )
+	{
+		return $self->render_citation( $use_citation );
+	}
 	return $self->render_value( "name" );
 }
 

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -4191,7 +4191,7 @@ each subject.
 
 sub render_subjects
 {
-	my( $self, $subject_list, $baseid, $currentid, $linkmode, $sizes ) = @_;
+	my( $self, $subject_list, $baseid, $currentid, $linkmode, $sizes, $use_citation ) = @_;
 
 	# If sizes is defined then it contains a hash subjectid->#of subjects
 	# we don't do this ourselves.
@@ -4208,7 +4208,7 @@ sub render_subjects
 		$subs{$_} = EPrints::DataObj::Subject->new( $self, $_ );
 	}
 
-	return $self->_render_subjects_aux( \%subs, $baseid, $currentid, $linkmode, $sizes );
+	return $self->_render_subjects_aux( \%subs, $baseid, $currentid, $linkmode, $sizes, $use_citation );
 }
 
 ######################################################################
@@ -4221,7 +4221,7 @@ sub render_subjects
 
 sub _render_subjects_aux
 {
-	my( $self, $subjects, $id, $currentid, $linkmode, $sizes ) = @_;
+	my( $self, $subjects, $id, $currentid, $linkmode, $sizes, $use_citation ) = @_;
 
 	my( $ul, $li, $elementx );
 	$ul = $self->make_element( "ul" );
@@ -4259,7 +4259,7 @@ sub _render_subjects_aux
 		}
 	}
 	$li->appendChild( $elementx );
-	$elementx->appendChild( $subjects->{$id}->render_description() );
+	$elementx->appendChild( $subjects->{$id}->render_description( $use_citation ) );
 	if( defined $sizes && defined $sizes->{$id} && $sizes->{$id} > 0 )
 	{
 		$li->appendChild( $self->make_text( " (".$sizes->{$id}.")" ) );
@@ -4269,7 +4269,7 @@ sub _render_subjects_aux
 	{
 		my $thisid = $_->get_value( "subjectid" );
 		next unless( defined $subjects->{$thisid} );
-		$li->appendChild( $self->_render_subjects_aux( $subjects, $thisid, $currentid, $linkmode, $sizes ) );
+		$li->appendChild( $self->_render_subjects_aux( $subjects, $thisid, $currentid, $linkmode, $sizes, $use_citation ) );
 	}
 	
 	return $ul;

--- a/perl_lib/EPrints/Update/Views.pm
+++ b/perl_lib/EPrints/Update/Views.pm
@@ -1669,6 +1669,7 @@ sub render_subj_menu
 			push @{$subjects_to_show}, $value;
 		}
 	}
+	my $use_citation = defined $menu->{use_subject_citation} ? $menu->{use_subject_citation} : "edit";
 
 	my $f = $repo->make_doc_fragment;
 	foreach my $field ( @{$fields} )
@@ -1679,7 +1680,10 @@ sub render_subj_menu
 				defined $menu->{top} ? $menu->{top} : $field->get_property( "top" ),
 				undef,
 				($has_submenu?3:2),
-				$sizes ) );
+				$sizes,
+				$use_citation,
+			)
+		);
 	}
 
 	return $f;
@@ -1781,6 +1785,7 @@ sub render_navigation_aids
 		
 		my $mode = 2;
 		if( $pagetype eq "menu" ) { $mode = 4; }
+		my $use_citation = defined $menu->{use_subject_citation} ? $menu->{use_subject_citation} : "edit";
 		foreach my $field ( @{$menu_fields} )
 		{
 			my $div_box = $repo->make_element( "div", class=>"ep_toolbox" );
@@ -1793,7 +1798,10 @@ sub render_navigation_aids
 					defined $menu->{top} ? $menu->{top} : $field->get_property( "top" ),
 					$path_values->[-1], 
 					$mode, 
-					$opts{sizes} ) );
+					$opts{sizes},
+					$use_citation,
+				)
+			);
 		}
 	}
 


### PR DESCRIPTION
By default a subject's render_description methods with be called for a browse view with `$use_citation = "edit";`.  If someone does not want it to display the "#Untitled subject..." used by the edit subject citation, they will need to add to the appropriate menus in the view that use a subject field and set:

```use_subject_citation => 0,```

Otherwise, they can choose a different citation, e.g.

```use_subject_citation => 'screen',```