### PR TITLE
Add 'export_file_as_attachment' option to force exports to be downloaded

### DIFF
--- a/cgi/export
+++ b/cgi/export
@@ -301,8 +301,10 @@ sub export_dataobj
 	# Set the Content-Disposition field to 'attachment' rather than its default
 	# value of 'inline'. This will "force" the browser to download the file
 	# rather than showing it in-browser.
-	if( $repository->config( 'export_file_as_attachment' ) ) {
-		$r->headers_out->add( 'Content-Disposition' => 'attachment' );
+	if( $repository->config( 'export_file_as_attachment' ) || defined $plugin->param( 'content_disposition' ) ) {
+		# Allow plugins to override the default on a case-by-case basis
+		my $content_disposition = $plugin->param( 'content_disposition' ) || 'attachment';
+		$r->headers_out->add( 'Content-Disposition' => $content_disposition );
 	}
 
 	my $dataset = $repository->dataset( $datasetid );

--- a/cgi/export
+++ b/cgi/export
@@ -298,6 +298,13 @@ sub export_dataobj
 
 	my $r = $repository->get_request;
 
+	# Set the Content-Disposition field to 'attachment' rather than its default
+	# value of 'inline'. This will "force" the browser to download the file
+	# rather than showing it in-browser.
+	if( $repository->config( 'export_file_as_attachment' ) ) {
+		$r->headers_out->add( 'Content-Disposition' => 'attachment' );
+	}
+
 	my $dataset = $repository->dataset( $datasetid );
 	$repository->not_found( "No such dataset" ), exit if !defined $dataset;
 

--- a/cgi/exportview
+++ b/cgi/exportview
@@ -111,12 +111,14 @@ my $list = $view->dataset->search(
 	filters => $filters );
 
 $session->send_http_header( "content_type"=>$plugin->param("mimetype") );
-	
+
 # Set the Content-Disposition field to 'attachment' rather than its default
 # value of 'inline'. This will "force" the browser to download the file rather
 # than showing it in-browser.
-if( $session->config( 'export_file_as_attachment' ) ) {
-	$session->get_request->headers_out->add( 'Content-Disposition' => 'attachment' );
+if( $session->config( 'export_file_as_attachment' ) || defined $plugin->param( 'content_disposition' ) ) {
+	# Allow plugins to override the default on a case-by-case basis
+	my $content_disposition = $plugin->param( 'content_disposition' ) || 'attachment';
+	$session->get_request->headers_out->add( 'Content-Disposition' => $content_disposition );
 }
 
 $plugin->initialise_fh( \*STDOUT );

--- a/cgi/exportview
+++ b/cgi/exportview
@@ -111,6 +111,14 @@ my $list = $view->dataset->search(
 	filters => $filters );
 
 $session->send_http_header( "content_type"=>$plugin->param("mimetype") );
+	
+# Set the Content-Disposition field to 'attachment' rather than its default
+# value of 'inline'. This will "force" the browser to download the file rather
+# than showing it in-browser.
+if( $session->config( 'export_file_as_attachment' ) ) {
+	$session->get_request->headers_out->add( 'Content-Disposition' => 'attachment' );
+}
+
 $plugin->initialise_fh( \*STDOUT );
 
 my %arguments = %{$plugin->param( "arguments" )};


### PR DESCRIPTION
By default with 'export_file_as_attachment' unset (or set to `0`) the behaviour will remain the same as 'Content-Disposition' generally defaults to inline (although I don't know that this is actually specified in the spec). When it is set to `1` however the files generated by 'Export' on searches/browse views (`cgi/exportview`) and those generated by 'Export' on a single EPrint (`cgi/export`) will inform the browser that it should always download them (rather than attempt to show them in-browser when recognised). This appears to be generally followed across browsers although I have seen mentions that some mobile browsers may disregard it.

Fixes #492.