### PR TITLE
Fix metatag issue on EPrints without a pagerange field

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -98,9 +98,11 @@ sub convert_dataobj
 	push @tags, [ 'citation_isbn', $eprint->get_value( 'isbn' ) ] if $eprint->exists_and_set( 'isbn' );
 	push @tags, [ 'citation_volume', $eprint->get_value( 'volume' ) ] if $eprint->exists_and_set( 'volume' );
 	push @tags, [ 'citation_issue', $eprint->get_value( 'number' ) ] if $eprint->exists_and_set( 'number' );
-	my( $firstpage, $lastpage ) = EPrints::MetaField::Pagerange::split_range( $eprint->get_value( 'pagerange' ) );
-	push @tags, [ 'citation_firstpage', $firstpage ] if defined $firstpage;
-	push @tags, [ 'citation_lastpage', $lastpage ] if defined $lastpage;
+	if( $eprint->exists_and_set( 'pagerange' ) ) {
+		my( $firstpage, $lastpage ) = EPrints::MetaField::Pagerange::split_range( $eprint->get_value( 'pagerange' ) );
+		push @tags, [ 'citation_firstpage', $firstpage ] if defined $firstpage;
+		push @tags, [ 'citation_lastpage', $lastpage ] if defined $lastpage;
+	}
 
 	# E. For theses, dissertations and technical reports provide the remaining
 	#    data in 'citation_dissertation_institution', 'citation_technical_report_institution' and

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
@@ -86,13 +86,15 @@ sub convert_dataobj
 	# 4.2.43 prism:modificationDate
 	push @tags, [ 'prism.modificationDate', parse_date( $eprint->get_value( 'lastmod' ) ) ] if $eprint->exists_and_set( 'lastmod' );
 
-	# 4.2.54 prism:pageRange
-	push @tags, [ 'prism.pageRange', $eprint->get_value( 'pagerange' ) ] if $eprint->exists_and_set( 'pagerange' );
-	my( $starting_page, $ending_page ) = EPrints::MetaField::Pagerange::split_range( $eprint->get_value( 'pagerange' ) );
-	# 4.2.70 prism:startingPage
-	push @tags, [ 'prism.startingPage', $starting_page ] if defined $starting_page;
-	# 4.2.23 prism:endingPage
-	push @tags, [ 'prism.endingPage', $ending_page ] if defined $ending_page;
+	if( $eprint->exists_and_set( 'pagerange' ) ) {
+		# 4.2.54 prism:pageRange
+		push @tags, [ 'prism.pageRange', $eprint->get_value( 'pagerange' ) ];
+		my( $starting_page, $ending_page ) = EPrints::MetaField::Pagerange::split_range( $eprint->get_value( 'pagerange' ) );
+		# 4.2.70 prism:startingPage
+		push @tags, [ 'prism.startingPage', $starting_page ] if defined $starting_page;
+		# 4.2.23 prism:endingPage
+		push @tags, [ 'prism.endingPage', $ending_page ] if defined $ending_page;
+	}
 	# 4.2.52 prism:pageCount
 	push @tags, [ 'prism.pageCount', $eprint->get_value( 'pages' ) ] if $eprint->exists_and_set( 'pages' );
 


### PR DESCRIPTION
This was caused by moving `split_pagerange` in b40f893 as previously that function did the checking of whether pagerange `exists_and_set` so the fix is to simply check before the new `Pagerange::split_range` function is called.