### PR TITLE
Prevent double presses on search buttons sending multiple requests

### DIFF
--- a/lib/static/javascript/auto/50_search_dedup.js
+++ b/lib/static/javascript/auto/50_search_dedup.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+	// Make all search buttons auto-disable when they are pressed to prevent
+	// multiple repeated requests being sent when the user isn't sure whether
+	// their click went through and tries again, exacerbating DDOS attacks.
+	document.getElementsByName('_action_search').forEach((element) => {
+		element.addEventListener('click', () => {
+			// By only disabling the element after 0 ticks it allows the current
+			// press to go through while still blocking future presses.
+			setTimeout(() => { element.disabled = true }, 0);
+		});
+	});
+});
+
+// Make sure we remove the `disabled` tag every time we load the page
+//
+// This is required because when you use the back arrow the browser just uses a
+// cached version of the previous page so will included the `disabled` tag in
+// it. This does however trigger `pageshow` so we can remove them once it loads.
+window.addEventListener('pageshow', () => {
+	document.getElementsByName('_action_search').forEach((element) => {
+		element.disabled = false;
+	});
+});
+


### PR DESCRIPTION
If a user clicks the search button and then clicks it again because they're not sure whether it went through they end up sending another request. While it appears the browser will cancel the first request (as a new one has taken priority) it may well be that this still dispatches a variety of database queries - and there is no particular reason to allow it.

This prevents double presses by disabling the search button after its first click event (as recognised by `name: '_action_search'` which appears to only be used by searches). There is then a bit of further complexity to re-enable the button when we come back to the page as the back button is complicated on a modern browser.