### PR TITLE
Mark the '<meta>' sections with comments

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/DC.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/DC.pm
@@ -53,6 +53,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " Dublin Core meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ));
 
 	$links->appendChild( $plugin->{session}->make_element(
 		"link",

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -28,6 +28,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " Highwire Press meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ));
 
 	my $tags = $plugin->convert_dataobj( $dataobj, "no_cache" => 1 );
 	for my $tag (@{$tags})

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
@@ -28,6 +28,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " PRISM meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ));
 
 	$links->appendChild( $plugin->{session}->make_element(
 		"link",

--- a/perl_lib/EPrints/Plugin/Export/Simple.pm
+++ b/perl_lib/EPrints/Plugin/Export/Simple.pm
@@ -47,6 +47,8 @@ sub dataobj_to_html_header
 	my( $plugin, $dataobj ) = @_;
 
 	my $links = $plugin->{session}->make_doc_fragment;
+	$links->appendChild( $plugin->{session}->make_comment( " EPrints meta tags " ) );
+	$links->appendChild( $plugin->{session}->make_text( "\n" ));
 
 	my $epdata = $plugin->convert_dataobj( $dataobj, "no_cache" => 1 );
 	foreach( @{$epdata} )


### PR DESCRIPTION
As PRed for `metatags` in eprints/metatags#4 this adds HTML comments to the top of the 'Highwire Press' and 'PRISM' `<meta>` tag sections, as well as adding them to the pre-existing 'Dublin Core' and 'EPrints' tags.

While these tags are absolutely not designed for humans to read it feels unnecessary to actively avoid human readability so this is a very small change to help slightly if scanning through the tags (which also makes it easier to see which tags a particular repository has enabled).