### PR TITLE
Fix sample EP_TRIGGER_BEGIN and EP_TRIGGER_END subroutines

### DIFF
--- a/lib/cfg.d/session.pl
+++ b/lib/cfg.d/session.pl
@@ -3,11 +3,11 @@
 # EP_TRIGGER_BEGIN replaces $c->{session_init}
 #
 #  Invoked each time a new repository is needed (generally one per
-#  script invocation.) $repository is a repository object that can be used
+#  script invocation.) $params{repository} is a repository object that can be used
 #  to store any values you want. To prevent future clashes, prefix
 #  all of the keys you put in the hash with repository.
 #
-#  If $offline is non-zero, the repository is an `off-line' repository, i.e.
+#  If $params{offline} is non-zero, the repository is an `off-line' repository, i.e.
 #  it has been run as a shell script and not by the web server.
 #
 ######################################################################
@@ -16,7 +16,7 @@ $c->add_trigger( EP_TRIGGER_BEGIN,
 	sub {
 		my %params = @_;
 		my $repo = $params{repository};
-    	my $online = $params{online}; #is this session web-based
+    	my $offline = $params{offline};
 
 		my $old_conf_fn = "session_init";
 		my $new_trigger = "EP_TRIGGER_BEGIN";
@@ -25,7 +25,8 @@ $c->add_trigger( EP_TRIGGER_BEGIN,
 			$repo->log( "UPGRADE: configuration uses '$old_conf_fn'. Please review upgrade advice for triggers ($new_trigger)." );
 			$repo->call(
 				$old_conf_fn,
-				$online,
+				$repo,
+				$offline,
 			);
 		}
 	}, 
@@ -55,6 +56,7 @@ $c->add_trigger( EP_TRIGGER_END,
             $repo->log( "UPGRADE: configuration uses '$old_conf_fn'. Please review upgrade advice for triggers ($new_trigger)." );
             $repo->call(
                 $old_conf_fn,
+                $repo,
             );
         }
     },


### PR DESCRIPTION
The parameter keys passed to EP_TRIGGER_BEGIN are 'repository' and 'offline' (not 'online'):

https://github.com/eprints/eprints3.4/blob/027b65ce0272914c03fcb81a35d89f95372a8d6c/perl_lib/EPrints/Repository.pm#L224

As I understand it, `$repo->call` does not automatically insert `$repo` as the first parameter to the called function, so this needs to be added explicitly.

The documentation has also been updated to reflect the fact that the triggered function is passed a hash rather than having a fixed signature.