### PR TITLE
Prevent 'javascript:' URLs from being saved in URL fields

### DIFF
--- a/perl_lib/EPrints/MetaField/Url.pm
+++ b/perl_lib/EPrints/MetaField/Url.pm
@@ -36,6 +36,18 @@ sub get_sql_type
 	return $self->EPrints::MetaField::Longtext::get_sql_type( $session );
 }
 
+sub sql_row_from_value
+{
+	my( $self, $session, $value ) = @_;
+
+	return undef unless defined $value;
+	# Prevent 'javascript:' links from being saved as there are no benevolent
+	# uses for them.
+	return undef if $value =~ /^\s*javascript:/;
+
+	return $self->SUPER::sql_row_from_value( $session, $value );
+}
+
 sub get_property_defaults
 {
 	my( $self ) = @_;


### PR DESCRIPTION
There is no non-malicious use for a 'javascript:' URL at this point (they are a massive XSS risk) and therefore if one does get entered into a URL field it should be automatically cleared before even reaching the database.

The alternative is to instead check for it when rendering and show it as text in that case however this would require any custom `render_single_value` functions for URL to also handle this so it seems safer to just not allow it to be saved.

This does mean that the user won't be informed that they did something wrong (via validation) and the field will instead just not save however you can't really do this accidentally so it doesn't seem like a problem.

Fixes #510.