### PR TITLE
Add clear buttons to multiple 'Compound' fields

### DIFF
--- a/lib/static/javascript/auto/87_component_field.js
+++ b/lib/static/javascript/auto/87_component_field.js
@@ -61,3 +61,13 @@ var Component_Field = Class.create({
 		});
 	}
 });
+
+const EPJS_clear_row = (basename, index) => {
+	// Find all elements in this row that are 'input' or 'select'
+	const elements = document.querySelectorAll(`div[id^=${basename}_cell_][id$=_${index}] > input, div[id^=${basename}_cell_][id$=_${index}] > select`);
+	elements.forEach((el) => {
+		el.value = '';
+	});
+
+	return false;
+};

--- a/perl_lib/EPrints/MetaField.pm
+++ b/perl_lib/EPrints/MetaField.pm
@@ -1567,6 +1567,18 @@ sub get_input_elements
 				$row_label->appendChild( $session->make_text( $i.". " ) );
 				$col1 = { el=>$row_label, class=>"ep_form_input_grid_pos" };
 				my $arrows = $session->make_doc_fragment;
+
+				$arrows->appendChild( $session->make_element(
+					'input',
+					type => 'image',
+					src => "$imagesurl/delete.png",
+					alt => 'down',
+					title => 'clear',
+					name => "_internal_${basename}_clear_$i",
+					onclick => "return EPJS_clear_row('$basename', $i - 1);",
+				) );
+				$arrows->appendChild( $session->make_text( ' ' ) );
+
 				$arrows->appendChild( $session->make_element(
 					"input",
 					type=>"image",


### PR DESCRIPTION
This is similar to the equivalent PR for 3.5 (eprints/eprints3.5#218) however simpler. Because there is no contributors field it doesn't have to handle clearing `span`s and it also doesn't handle defaults. This is both because there are no core clearable defaults (as `contributors` is the only one) and because that change ends up being a bit more involved and is therefore better suited for 3.5.

Fixes #368.