### PR TITLE
Add an export plugin for document URLs

### DIFF
--- a/perl_lib/EPrints/Plugin/Export/Urls.pm
+++ b/perl_lib/EPrints/Plugin/Export/Urls.pm
@@ -1,0 +1,79 @@
+=head1 NAME
+
+EPrints::Plugin::Export::Urls
+
+=cut
+
+package EPrints::Plugin::Export::Urls;
+
+use EPrints::Plugin::Export;
+
+@ISA = ( "EPrints::Plugin::Export" );
+
+use strict;
+
+sub new
+{
+	my( $class, %opts ) = @_;
+
+	my $self = $class->SUPER::new( %opts );
+
+	$self->{name} = 'Document URLs';
+	$self->{accept} = [ 'list/*' ];
+	$self->{visible} = 'all';
+	$self->{suffix} = '.html';
+	$self->{mimetype} = 'text/html; charset=utf-8';
+	
+	return $self;
+}
+
+sub output_list
+{
+	my( $plugin, %opts ) = @_;
+
+	my $fh = $opts{fh};
+	my $value = undef;
+	open $fh, '>', \$value unless defined $fh;
+
+	for my $eprint ($opts{list}->get_records) {
+		for my $document ($eprint->get_all_documents) {
+			next unless $document->is_public;
+			print {$fh} '<a href="' . $document->get_url . '">' . $document->get_url . '</a><br />';
+		}
+	}
+
+	return $value;
+}
+
+1;
+
+=head1 COPYRIGHT
+
+=for COPYRIGHT BEGIN
+
+Copyright 2025 University of Southampton.
+EPrints 3.4 is supplied by EPrints Services.
+
+http://www.eprints.org/eprints-3.4/
+
+=for COPYRIGHT END
+
+=for LICENSE BEGIN
+
+This file is part of EPrints 3.4 L<http://www.eprints.org/>.
+
+EPrints 3.4 and this file are released under the terms of the
+GNU Lesser General Public License version 3 as published by
+the Free Software Foundation unless otherwise stated.
+
+EPrints 3.4 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with EPrints 3.4.
+If not, see L<http://www.gnu.org/licenses/>.
+
+=for LICENSE END
+

--- a/perl_lib/EPrints/Plugin/Export/Urls.pm
+++ b/perl_lib/EPrints/Plugin/Export/Urls.pm
@@ -37,7 +37,7 @@ sub output_list
 
 	for my $eprint ($opts{list}->get_records) {
 		for my $document ($eprint->get_all_documents) {
-			next unless $document->is_public;
+			next unless $document->is_public || $document->user_can_view( $plugin->{repository}->current_user );
 			print {$fh} '<a href="' . $document->get_url . '">' . $document->get_url . '</a><br />';
 		}
 	}

--- a/perl_lib/EPrints/Plugin/Export/Urls.pm
+++ b/perl_lib/EPrints/Plugin/Export/Urls.pm
@@ -38,7 +38,10 @@ sub output_list
 	for my $eprint ($opts{list}->get_records) {
 		for my $document ($eprint->get_all_documents) {
 			next unless $document->is_public || $document->user_can_view( $plugin->{repository}->current_user );
-			print {$fh} '<a href="' . $document->get_url . '">' . $document->get_url . '</a><br />';
+
+			my $link = '<a href="' . $document->get_url . '">' . $document->get_url . '</a>';
+			$link .= ' (private)' unless $document->is_public;
+			print {$fh} $link . '<br />';
 		}
 	}
 


### PR DESCRIPTION
This generates a simple HTML file containing links to all of the public documents the given search contains. This should both be easier to download them all by hand and very easy to parse with a script as it would just have to look for `href="..."`.

This will show all documents that the user could access (so if an admin is logged in it would include all documents) rather than just those that are public. When there are private links in among them it will add `(private)` to make it clear that they shouldn't be shared to someone without admin permissions.

Fixes #386.