### PR TITLE
Remove the progress bar even if a document upload fails.

### DIFF
--- a/lib/static/javascript/auto/88_uploadmethod_file.js
+++ b/lib/static/javascript/auto/88_uploadmethod_file.js
@@ -116,14 +116,10 @@ const Screen_EPrint_UploadMethod_File = Class.create({
 
 function UploadMethod_process_file(form, formData, prefix, component, fileLabel) {
 
-	const uuid = generate_uuid();
-	const progress = `${uuid}_progress`;
-
 	const xhr = new XMLHttpRequest();
 
 	// progress status
 	const progressRow = document.createElement('div');
-	progressRow.setAttribute('id', progress);
 
 	const progressContainer = progressRow;
 
@@ -172,7 +168,6 @@ function UploadMethod_process_file(form, formData, prefix, component, fileLabel)
 
 	const uploadUrl = new URL(form.getAttribute('action'), window.location.href);
 
-	uploadUrl.searchParams.set('progressid', uuid);
 	uploadUrl.searchParams.set('ajax', 'add_format');
 
 	// Mark this request as an internal button to the server code. Internal

--- a/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/File.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/File.pm
@@ -54,7 +54,6 @@ sub export
 
 	my %q = URI::http->new( $repo->get_request->unparsed_uri )->query_form;
 
-	my $progressid = $q{progressid};
 	my $ajax = $q{ajax};
 
 	if( $ajax eq "add_format" )
@@ -65,9 +64,10 @@ sub export
 			$messages =~ s/"/\\"/g;
 		}
 
-		print '{"progressid": "' . $progressid . '"';
-		print ', "docid": ' . $doc->id if defined $doc;
-		print ', "messages": "' . $messages . '"' if defined $messages;
+		print '{';
+		print '"docid": ' . $doc->id if defined $doc;
+		print ', ' if defined $doc and defined $messages;
+		print '"messages": "' . $messages . '"' if defined $messages;
 		print '}';
 
 		return;


### PR DESCRIPTION
This also shows any Processor messages raised by the upload process (such as 'File upload failed.') in the `ep_messages` box. This is slightly awkward to test as the main way that this could fail is if it runs out of disk space however you can fake it by replacing line 117 of `perl_lib/EPrints/Plugin/Screen/EPrint/UploadMethod/File.pm` (`my $doc = ...`) with `my $doc = undef;`.

Fixes #446.