### PR TITLE
Make the default encoding of imports 'UTF-8'

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Import.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Import.pm
@@ -63,7 +63,7 @@ sub new
 	$self->{show_stderr} = 1;
 
 	$self->{encodings} = \@ENCODINGS;
-	$self->{default_encoding} = "iso-8859-1";
+	$self->{default_encoding} = "UTF-8";
 
 	return $self;
 }


### PR DESCRIPTION
UTF-8 won as it is massively more useful (as it has full Unicode support) than iso-8859-1 (Latin 1) so we should assume that incoming files are UTF-8 by default.

While it is useful to have the option to set the encoding (as some files are Latin 1) most users don't know what encoding their files are so we should make the best guess, which is definitely UTF-8.

Fixes #516.