### PR TITLE
Add support for number format months to BibTex import

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Import/BibTeX.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Import/BibTeX.pm
@@ -508,12 +508,12 @@ sub convert_input
 			dec => "12",
 		);
 		my $month = substr( lc( $entry->field( "month" ) ), 0, 3 );
-		if( defined $months{$month} && defined $epdata->{date})
-		{
+		if( defined $months{$month} && defined $epdata->{date}) {
 			$epdata->{date} .= "-" . $months{$month};
-		}
-		else
-		{
+		} elsif( $month >= 1 && $month <= 12 ) {
+			# If the month is already a number, pad it two digits
+			$epdata->{date} .= '-' . sprintf( '%02d', $month );
+		} else {
 			$plugin->warning( $plugin->phrase( "skip_month", month => $month ) );
 		}
 	}


### PR DESCRIPTION
Months in BibTex can be formatted in three different ways, 'February', 'feb' and '2'. The import plugin supported the first two of these but not the third format so this just adds a simple integer comparison check for that and pads it to two digits.

Fixes #517.