### PR TITLE
Make clicking the description of a radio button count as the button

### DIFF
--- a/perl_lib/EPrints/MetaField/Boolean.pm
+++ b/perl_lib/EPrints/MetaField/Boolean.pm
@@ -174,8 +174,9 @@ sub get_basic_input_elements
 			$dt->appendChild( $inputs->{$option} );
 			$f->appendChild( $dt );
 			my $dd = $session->make_element( "dd", id => $basename . "_" . $option . "_label" );
-			$dd->appendChild( $session->html_phrase( $self->{confid} . "_radio_" . $self->{name} . "_" . $option ) ) unless $option eq "unspecified";
-			$dd->appendChild( $self->unspecified_phrase( $session ) ) if $option eq "unspecified";
+			my $label = $dd->appendChild( $session->make_element( 'label', for => "${basename}_$option" ) );
+			$label->appendChild( $session->html_phrase( $self->{confid} . "_radio_" . $self->{name} . "_" . $option ) ) unless $option eq "unspecified";
+			$label->appendChild( $self->unspecified_phrase( $session ) ) if $option eq "unspecified";
 			$f->appendChild( $dd );
 		}
 		

--- a/perl_lib/EPrints/MetaField/Set.pm
+++ b/perl_lib/EPrints/MetaField/Set.pm
@@ -328,8 +328,9 @@ sub render_set_input
 				) );
 	                	$row->appendChild( $session->make_text( " ".$labels->{$opt} ));
         	        	$dd = $session->make_element( "dd", id=>$basename."_".$opt."_desc" );
+						my $label = $session->make_element( 'label', for => "${basename}_$opt" );
                 		my $phrasename = $self->{confid}."_optdetails_".$self->{name}."_".$opt;
-                		$dd->appendChild( $session->html_phrase( $phrasename ));
+                		$label->appendChild( $session->html_phrase( $phrasename ));
 			}
 			else 
 			{
@@ -343,8 +344,9 @@ sub render_set_input
 	                                checked => $checked,
                                         'aria-labelledby' => $basename."_".$opt."_label",
                 	        ) );
-	                        $dd = $session->make_element( "dd", id=>$basename."_".$opt."_label", 'aria-describedby'=>$self->get_labelledby( $basename ) );
-				$dd->appendChild( $session->make_text( $labels->{$opt} ) );
+				$dd = $session->make_element( "dd", id=>$basename."_".$opt."_label", 'aria-describedby'=>$self->get_labelledby( $basename ) );
+				my $label = $dd->appendChild( $session->make_element( 'label', for => "${basename}_$opt" ) );
+				$label->appendChild( $session->make_text( $labels->{$opt} ) );
 			}
 			$list->appendChild( $row );
                         $list->appendChild( $dd );


### PR DESCRIPTION
This allows the description of the button to be clicked and still control the button itself, as is the convention (as it makes it easier to click).

#### 3.4 version of the fix for eprints/eprints3.5#227