### PR TITLE
Check that `$id->{id_type}` is set before comparing it

### DIFF
--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -130,8 +130,10 @@ sub convert_dataobj
 	push @tags, simple_value( $eprint, 'publisher' );
 	if( $eprint->exists_and_set( 'ids' ) ) {
 		for my $id ( @{$eprint->get_value( 'ids' )} ) {
-			push @tags, [ 'citation_doi', $id->{id} ] if $id->{id_type} eq 'doi';
-			push @tags, [ 'citation_pmid', $id->{id} ] if $id->{id_type} eq 'pmid';
+			if( defined $id->{id} && defined $id->{id_type} ) {
+				push @tags, [ 'citation_doi', $id->{id} ] if $id->{id_type} eq 'doi';
+				push @tags, [ 'citation_pmid', $id->{id} ] if $id->{id_type} eq 'pmid';
+			}
 		}
 	}
 	push @tags, simple_value( $eprint, 'abstract' );

--- a/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/flavours/pub_lib/plugins/EPrints/Plugin/Export/Prism.pm
@@ -103,7 +103,9 @@ sub convert_dataobj
 	# 4.2.20 prism:doi
 	if( $eprint->exists_and_set( 'ids' ) ) {
 		for my $id ( @{$eprint->get_value( 'ids' )} ) {
-			push @tags, [ 'prism.doi', $id->{id} ] if $id->{id_type} eq 'doi';
+			if( defined $id->{id} && defined $id->{id_type} ) {
+				push @tags, [ 'prism.doi', $id->{id} ] if $id->{id_type} eq 'doi';
+			}
 		}
 	}
 	# 4.2.31 prism:isbn


### PR DESCRIPTION
The metatag exports do comparisons on this without checking it exists which can cause unnecessary log spam.

Core PR equivalent to eprints/metatags#12.