### PR TITLE
Don't add export link elements to deleted item page head

### DIFF
--- a/perl_lib/EPrints/DataObj/EPrint.pm
+++ b/perl_lib/EPrints/DataObj/EPrint.pm
@@ -1549,28 +1549,32 @@ sub generate_static
 		$links->appendChild( $link );
 		$links->appendChild( $self->{session}->make_text( "\n" ) );
 
-		my @plugins = $self->{session}->plugin_list( 
-					type=>"Export",
-					can_accept=>"dataobj/".$self->{dataset}->confid, 
-					is_advertised => 1,
-					is_visible=>"all" );
-		if( scalar @plugins > 0 ) {
-			foreach my $plugin_id ( @plugins ) 
-			{
-				$plugin_id =~ m/^[^:]+::(.*)$/;
-				my $id = $1;
-				my $plugin = $self->{session}->plugin( $plugin_id );
-				my $link = $self->{session}->make_element( 
-					"link", 
-					rel=>"alternate",
-					href=>$plugin->dataobj_export_url( $self ),
-					type=>$plugin->param("mimetype"),
-					title=>EPrints::XML::to_string( $plugin->render_name ), );
-				$links->appendChild( $link );
-				$links->appendChild( $self->{session}->make_text( "\n" ) );
+		if( $status ne "deletion" )
+		{
+			my @plugins = $self->{session}->plugin_list(
+						type=>"Export",
+						can_accept=>"dataobj/".$self->{dataset}->confid,
+						is_advertised => 1,
+						is_visible=>"all" );
+			if( scalar @plugins > 0 ) {
+				foreach my $plugin_id ( @plugins )
+				{
+					$plugin_id =~ m/^[^:]+::(.*)$/;
+					my $id = $1;
+					my $plugin = $self->{session}->plugin( $plugin_id );
+					my $link = $self->{session}->make_element(
+						"link",
+						rel=>"alternate",
+						href=>$plugin->dataobj_export_url( $self ),
+						type=>$plugin->param("mimetype"),
+						title=>EPrints::XML::to_string( $plugin->render_name ), );
+					$links->appendChild( $link );
+					$links->appendChild( $self->{session}->make_text( "\n" ) );
+				}
 			}
 		}
-		$self->{session}->write_static_page( 
+
+		$self->{session}->write_static_page(
 			$full_path . "/index",
 			{title=>$title, page=>$page, head=>$links, template=>$self->{session}->make_text($template) },
 			 );


### PR DESCRIPTION
Fixes #533 .

When generating static for a retired item, don't include export `<link ...>` elements.