### PR TITLE
Issue 526 oai2

### DIFF
--- a/cgi/oai2
+++ b/cgi/oai2
@@ -30,7 +30,7 @@ our $METADATAPREFIX_REGEXP = qr/^[A-Za-z0-9\-_\.!~\*'\(\)]+$/;
 our $IDENTIFIER_REGEXP = qr/^[a-z]+:.*$/;
 our $DATETIME_REGEXP = qr/^\d\d\d\d-\d\d-\d\d(T\d\d:\d\d:\d\dZ)?$/;
 
-our $DATESTAMP_FIELD = $repo->dataset( "eprint")->get_datestamp_field;
+our $DATESTAMP_FIELD = $repo->dataset( "eprint" )->get_datestamp_field;
 our $ARCHIVE_ID = EPrints::OpenArchives::archive_id( $repo );
 
 # OAI-PMH grammar
@@ -233,14 +233,14 @@ sub render_text_url
 
 	my $node = $repo->xml->create_element( $name );
 
-	if ( defined $texturl->{"text"} ) 
+	if ( defined $texturl->{"text"} )
 	{
 		$node->appendChild( $repo->xhtml->data_element(
 			"text",
 			$texturl->{"text"} ) );
 	}
 
-	if ( defined $texturl->{"url"} ) 
+	if ( defined $texturl->{"url"} )
 	{
 		$node->appendChild( $repo->xhtml->data_element(
 			"URL",
@@ -508,39 +508,39 @@ sub Identify
 
 	my $d2 = $repo->xml->create_element( "description" );
 	my $eprints = $repo->xml->create_element( 	
-		"eprints", 
+		"eprints",
 		"xmlns"=>"http://www.openarchives.org/OAI/1.1/eprints",
 		"xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance",
 		"xsi:schemaLocation"=>"http://www.openarchives.org/OAI/1.1/eprints http://www.openarchives.org/OAI/1.1/eprints.xsd" );
 	$d2->appendChild( $eprints );
 	$response->appendChild( $d2 );
 
-	$eprints->appendChild( render_text_url( 
+	$eprints->appendChild( render_text_url(
 		$repo,
-		"content", 
+		"content",
 		$repo->config( "oai","content" ) ) );
-                          
-	$eprints->appendChild( render_text_url( 
+
+	$eprints->appendChild( render_text_url(
 		$repo,
-		"metadataPolicy", 
+		"metadataPolicy",
 		$repo->config( "oai","metadata_policy" ) ) );
 
-	$eprints->appendChild( render_text_url( 
+	$eprints->appendChild( render_text_url(
 		$repo,
-		"dataPolicy", 
+		"dataPolicy",
 		$repo->config( "oai","data_policy" ) ) );
 
-	$eprints->appendChild( render_text_url( 
+	$eprints->appendChild( render_text_url(
 		$repo,
-		"submissionPolicy", 
+		"submissionPolicy",
 		$repo->config( "oai","submission_policy" ) ) );
 
 	if( $repo->config( "oai","comments" ) )
 	{
-		foreach( @{$repo->config( "oai","comments" )} ) 
+		foreach( @{$repo->config( "oai","comments" )} )
 		{
 			$eprints->appendChild( $repo->xhtml->data_element(
-				"comment", 
+				"comment",
 				$_ ) );
 		}
 	}
@@ -560,7 +560,7 @@ sub GetRecord
 
 	my $plugin = $args->{metadataPrefix};
 
-	$response->appendChild( 
+	$response->appendChild(
 		EPrints::OpenArchives::make_record(
 			$repo,
 			$eprint,
@@ -672,29 +672,29 @@ sub ListSets
 			}
 		}
 		unless( $info->{allow_null} ) { delete $v{""}; }
-		foreach( keys %v ) 
+		foreach( keys %v )
 		{	
 			my $set = $repo->xml->create_element( "set" );
 			$response->appendChild( $set );
 			my $spec = EPrints::OpenArchives::encode_setspec( $info->{id}."=" ).$_;
-			$set->appendChild( $repo->xhtml->data_element( 
+			$set->appendChild( $repo->xhtml->data_element(
 				"setSpec",
 				$spec ) );
 			my $name = $repo->get_view_name( $ds, $info->{id} )." = ".$v{$_};
-			$set->appendChild( $repo->xhtml->data_element( 
+			$set->appendChild( $repo->xhtml->data_element(
 				"setName",
 				$name ) );
 		}
 	}
-	my $custom_sets = $repo->config( "oai", "custom_sets");
+	my $custom_sets = $repo->config( "oai", "custom_sets" );
 	foreach my $info (@{$custom_sets||[]})
 	{
 		my $set = $repo->xml->create_element( "set" );
 		$response->appendChild( $set );
-		$set->appendChild( $repo->xhtml->data_element( 
+		$set->appendChild( $repo->xhtml->data_element(
 			"setSpec",
 			$info->{spec} ) );
-		$set->appendChild( $repo->xhtml->data_element( 
+		$set->appendChild( $repo->xhtml->data_element(
 			"setName",
 			$info->{name} ) );
 	}
@@ -822,10 +822,10 @@ sub _list
 			limit => ($PAGESIZE+1) );
 
 	my $fullsearchexp = $ds->prepare_search(
-            allow_blank => 1,
-            filters => [
-                @{$filters},
-            ] );	
+		allow_blank => 1,
+		filters => [
+			@{$filters},
+		] );	
 
 	if( defined $args->{offset} )
 	{
@@ -902,7 +902,7 @@ END
 	}
 	
 	my $list = $searchexp->perform_search();
-    my $fulllist = $fullsearchexp->perform_search();
+	my $fulllist = $fullsearchexp->perform_search();
 	my @records = $list->slice( 0, $PAGESIZE );
 
 	if( @records == 0 )
@@ -936,7 +936,7 @@ END
 	{
 		foreach my $eprint ( @records )
 		{
-			$response->appendChild( 
+			$response->appendChild(
 				EPrints::OpenArchives::make_record(
 					$repo,
 					$eprint,


### PR DESCRIPTION
Fixes #526 

Summary of logic:
- any EPrint that has the 'datestamp' field set may have been exposed in the OAI-PMH interface
- the 'OAI-PMH datestamp' is equivalent to the eprint.lastmod field
- if eprint.datestamp is set, and the eprint is _not_ in the archive, the eprint should be represented as 'deleted' in the OAI-PMH interface. NB this does not mean the eprint has been deleted - just that the metadata representation in harvested data should be removed.

Tests:
- get 'Identify' response from OAI-PMH interface e.g. https://example.com/cgi/oai2?verb=Identify
- get 'Earliest Datestamp' value e.g. 2026-01-11T23:00:00Z
- request 'ListIdentifiers' with an 'until' parameter one second earlier than the Earliest Timestamp e.g. https://example.com/cgi/oai2?verb=ListIdentifiers&metadataPrefix=oai_dc&until=2026-01-11T22:59:59Z . This should return a 'noRecordsMatch' error.
- in the EPrints database, find the earliest lastmod date/time of a record that has the datestamp set: `SELECT eprintid, eprint_status FROM eprint WHERE datestamp_year IS NOT NULL ORDER BY lastmod_year, lastmod_month, lastmod_day, lastmod_hour, lastmod_minute, lastmod_second LIMIT 1;`. If this record is in the 'archive', the eprintid should match the 'Sample OAI Identifier' in the 'Identity' response.
- if the above record is not in the archive, the 'Sample OAI Identifier' should match the following query: `SELECT eprintid FROM eprint WHERE eprint_status = 'archive' AND datestamp_year IS NOT NULL ORDER BY lastmod_year, lastmod_month, lastmod_day, lastmod_hour, lastmod_minute, lastmod_second LIMIT 1;`
