### PR TITLE
Improve cache_table method to be compatible with uuids

### DIFF
--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -2102,9 +2102,12 @@ Return the name of the SQL table used to store the cache with C<$id>.
 
 sub cache_table
 {
-	my( $self, $id ) = @_;
+    my( $self, $id ) = @_;
 
-	return "cache".$id;
+	my $cachemap = $self->get_cachemap( $id );
+	return $cachemap->get_sql_table_name() if $cachemap;
+
+    EPrints::abort( "Cache with ID '$id' not found" );
 }
 
 


### PR DESCRIPTION
Refactor cache_table to retrieve SQL table name from cachemap instead of using id directly in case the id is in fact a uuid. Corrects a bug introduced with changes in https://github.com/eprints/eprints3.4/issues/465