### PR TITLE
Check mod time of citation style file when using cached citations

### DIFF
--- a/perl_lib/EPrints/DataObj.pm
+++ b/perl_lib/EPrints/DataObj.pm
@@ -1635,8 +1635,9 @@ sub render_citation
 			my $citation_unixtime = EPrints::Time::datetime_utc( EPrints::Time::split_value( $res->get_value( 'timestamp' ) ) );	
 			my $timestampfile = $self->{session}->get_conf( "variables_path" )."/citations.timestamp";
 			my $refresh_unixtime = ( -e $timestampfile ) ? (stat( $timestampfile ))[9] : 0;
+			my $style_timestamp = $self->{session}->{citations}->{ $self->{dataset}->confid }->{$style}->{mtime} ||= 0;
 	
-			if ( $citation_unixtime > $refresh_unixtime ) 
+			if ( ( $citation_unixtime > $refresh_unixtime ) && ( $citation_unixtime > $style_timestamp ) )
 			{
 				$use_cached_version = 1;
 			}


### PR DESCRIPTION
If the citation file has changed, and a cached citation was created before that time, the cache should be updated.

The citation file already has it's modified time cached in the session object, so this feels like a low-cost check.

@drn05r I can't remember if we discussed this when looking at citation caches last year. If so, there may be a reason why _not_ checking the citation file timestamp was preferable?