### PR TITLE
Opensearch format config option

### DIFF
--- a/cgi/opensearch
+++ b/cgi/opensearch
@@ -41,6 +41,12 @@ if( defined $user && $user->is_staff  )
 }
 
 $format = 'Atom' if !EPrints::Utils::is_set( $format );
+
+my $permitted_formats = $repo->config( 'opensearch', 'formats' );
+if( defined $permitted_formats && ! grep { $format eq $_ } @$permitted_formats ){
+	EPrints->abort( "Format $format not permitted for opensearch." );
+};
+
 $format = $repo->plugin( "Export::$format" );
 
 if( !defined($format) || ! $format->is_visible( $is_visible ) )

--- a/cgi/opensearchdescription
+++ b/cgi/opensearchdescription
@@ -10,6 +10,8 @@ my $url = $repo->current_url( host => 1, path => 'cgi', 'opensearch' );
 $url .= '?q={searchTerms}&startPage={pageNumber}';
 
 my @formats;
+# Optional config to only offer specific formats
+my $permitted_formats = $repo->config( 'opensearch', 'formats' );
 
 my $is_visible = "all";
 my $user = $repo->current_user;
@@ -30,6 +32,8 @@ foreach my $plugin (sort { ref($a) cmp ref($b) } $repo->get_plugins(
 	is_visible => $is_visible,
 ))
 {
+	next if( defined $permitted_formats && ! grep { $plugin->get_subtype eq $_ } @$permitted_formats );
+
 	my $mt=$plugin->param( "mimetype" );
 	$mt=~s/;.*$//;
 	push @formats, [ 'Url', undef,

--- a/lib/cfg.d/opensearch_formats.pl
+++ b/lib/cfg.d/opensearch_formats.pl
@@ -1,0 +1,7 @@
+# This config option can be used to restrict which Export formats are offered/allowed in the opensearchdescription and opensearch interface.
+# If the option isn't defined, all export plugins that are visible to 'all' (if no user is present) or 'staff' (if an appropriate user is 
+# present) will be listed/supported.
+# Please include all formats that public or staff should have access to. The all/staff filters will still be used to refine which are offered.
+# 
+# At a minimum, the default 'Atom' format should be offered.
+# $c->{opensearch}->{formats} = [qw( Atom BibTeX DC EndNote HTML METS )];


### PR DESCRIPTION
Allows export formats offered in the opensearch interface to be restricted by a config option.

NB There's a new (comments-only) config file. If there's a better place for this example config to be stored, please merge it as appropriate.

Tests:
- no config option: opensearchdescription unchanged; opensearch unchanged
- example config option active: opensearchdescription should only list Atom, BibTeX, DC, EndNote, HTML, METS formats; opensearch with format=BibTex should work, opensearch with format=RIS should produce an error
