### PR TITLE
Implements #581 event_queue task priority setting

### DIFF
--- a/lib/cfg.d/event_queue.pl
+++ b/lib/cfg.d/event_queue.pl
@@ -1,0 +1,10 @@
+# Priorities for event_queue tasks.  Higher the number the more likely a task will run before other tasks.
+
+# Generic priority to set for a event_queue tasks create as a result of a web requests (e.g. workflow edit).
+$c->{event_queue}->{web_priority} = 10;
+
+# Priorities for calls to the CRUD API.  More likely these will be in bulk so should be deprioritsied.
+$c->{event_queue}->{priority_paths} = {
+	6 => '/id/contents',
+	5 => '/id/\w+/\d+',
+};

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -3894,6 +3894,7 @@ PY = 2006 and OG = (Cambridge)<br />
 <epp:phrase id="event_queue_fieldname_pluginid">Plugin</epp:phrase>
 <epp:phrase id="event_queue_fieldname_userid">Owner</epp:phrase>
 <epp:phrase id="event_queue_fieldhelp_status">The status of the task.</epp:phrase>
+<epp:phrase id="event_queue_fieldhelp_priority">The priority assigned to the task.  The higher the number the more likely it will be prioritised over other tasks. Negative numbers will further deprioritise a task.</epp:phrase>
 <epp:phrase id="event_queue_fieldhelp_start_time">The time the task is scheduled to start running.</epp:phrase>
 
 

--- a/lib/workflows/event_queue/default.xml
+++ b/lib/workflows/event_queue/default.xml
@@ -9,6 +9,7 @@
   <stage name="core">
   	<component><field ref="status"/></component>
   	<component><field ref="start_time"/></component>
+	<component><field ref="priority"/></component>
   </stage>
 
 </workflow>

--- a/perl_lib/EPrints/DataObj/EventQueue.pm
+++ b/perl_lib/EPrints/DataObj/EventQueue.pm
@@ -146,27 +146,33 @@ sub create_unique
         return $task;
     }
 
-	# If a priority is no explictly specified set priority on the request that prompted the task to be created.
-	if ( !defined $data->{priority} )
+	# Increment the priority if the task is create via a web request.
+	# Some request paths (e.g. CRUD API) will increment the priority by different (default lower) amounts.
+	my $priority = 0;
+	if ( my $request = $session->request )
+    {
+        my $urlpath = $session->config( "rel_path" );
+        my $uri = $request->uri;
+        $uri =~ s!^$urlpath!!;
+        $priority = $session->config( 'event_queue', 'web_priority' ) || 10;
+        my $priority_paths = $session->config( 'event_queue', 'priority_paths' );
+        foreach my $path_priority ( reverse sort keys %$priority_paths )
+        {
+            my $path = $priority_paths->{$path_priority};
+            if ( $uri =~ m!^$path$! )
+            {
+                $priority = $path_priority;
+                last;
+            }
+        }
+    }
+	if ( defined $data->{priority} )
 	{
-		if ( my $request = $session->request )
-		{
-			my $urlpath = $session->config( "rel_path" );
-			my $uri = $request->uri;
-			$uri =~ s!^$urlpath!!;
-			my $priority = $session->config( 'event_queue', 'web_priority' ) || 10;
-			my $priority_paths = $session->config( 'event_queue', 'priority_paths' );
-			foreach my $path_priority ( reverse sort keys %$priority_paths )
-			{
-				my $path = $priority_paths->{$path_priority};
-				if ( $uri =~ m!^$path$! )
-				{
-					$priority = $path_priority;
-					last;
-				}
-			}
-			$data->{priority} = $priority;
-		}
+		$data->{priority} += $priority;
+	}
+	else
+	{
+		$data->{priority} = $priority;
 	}
 
     # Some event queue plugins create 'staged' tasks that are logged by the indexer but executed by an external script, (e.g. video transcoding).

--- a/perl_lib/EPrints/DataObj/EventQueue.pm
+++ b/perl_lib/EPrints/DataObj/EventQueue.pm
@@ -146,6 +146,29 @@ sub create_unique
         return $task;
     }
 
+	# If a priority is no explictly specified set priority on the request that prompted the task to be created.
+	if ( !defined $data->{priority} )
+	{
+		if ( my $request = $session->request )
+		{
+			my $urlpath = $session->config( "rel_path" );
+			my $uri = $request->uri;
+			$uri =~ s!^$urlpath!!;
+			my $priority = $session->config( 'event_queue', 'web_priority' ) || 10;
+			my $priority_paths = $session->config( 'event_queue', 'priority_paths' );
+			foreach my $path_priority ( reverse sort keys %$priority_paths )
+			{
+				my $path = $priority_paths->{$path_priority};
+				if ( $uri =~ m!^$path$! )
+				{
+					$priority = $path_priority;
+					last;
+				}
+			}
+			$data->{priority} = $priority;
+		}
+	}
+
     # Some event queue plugins create 'staged' tasks that are logged by the indexer but executed by an external script, (e.g. video transcoding).
     my $plugin = $session->plugin( $data->{pluginid} );
     if ( defined $plugin )

--- a/perl_lib/EPrints/DataObj/EventQueue.pm
+++ b/perl_lib/EPrints/DataObj/EventQueue.pm
@@ -248,7 +248,7 @@ sub get_system_field_info
 	return (
 		{ name=>"eventqueueid", type=>"uuid", required=>1, },
 		{ name=>"cleanup", type=>"boolean", default_value=>"TRUE", },
-		{ name=>"priority", type=>"int", },
+		{ name=>"priority", type=>"int", required=>1, default_value=>0 },
 		{ name=>"start_time", type=>"timestamp", required=>1, },
 		{ name=>"end_time", type=>"time", },
 		{ name=>"status", type=>"set", options=>[qw( waiting staged inprogress success failed )], default_value=>"waiting", },

--- a/perl_lib/EPrints/DataSet.pm
+++ b/perl_lib/EPrints/DataSet.pm
@@ -212,7 +212,7 @@ my $INFO = {
 		sqlname => "event_queue",
 		class => "EPrints::DataObj::EventQueue",
 		datestamp => "start_time",
-		columns => [qw( status start_time pluginid action params )],
+		columns => [qw( status start_time pluginid action params priotity )],
 	},
 	upload_progress => {
 		sqlname => "upload_progress",

--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -3011,7 +3011,7 @@ sub dequeue_events
 				{ meta_fields => ["status"], value => "waiting" },
 				{ meta_fields => ["start_time"], value => "..$until", match => "EQ" },
 			],
-			custom_order => "-priority/-start_time",
+			custom_order => "-priority/start_time",
 			limit => $n,
 		)->slice( 0, $n );
 


### PR DESCRIPTION
- If priority is not sent in $data to EPrints::DataObj::EventQueue->create_unique set priority if task create as a result of a web request.
- Allow a default priority for web requests event_queue tasks to be set.
- Allow specific priority to be set of tasks create by web requests on particular path regexps.
- Update dequeue_events to secondarily sort by start_date ASC rather than DESC (primary sort still priority DESC).