### PR TITLE
Allow compound field to be validated as a whole. Fixes #589

### DIFF
--- a/perl_lib/EPrints/MetaField/Compound.pm
+++ b/perl_lib/EPrints/MetaField/Compound.pm
@@ -575,10 +575,21 @@ sub validate
 
 	my $f = $self->get_property( "fields_cache" );
 	my @problems;
+
+	# This will validate the individual sub-fields e.g. creators_name, creators_id, creators_orcid.
 	foreach my $field_conf ( @{$f} )
 	{
 		push @problems, $object->validate_field( $field_conf->{name} );
 	}
+
+	# This can validate the compound field as a whole - e.g. for a creator, does a 'row' that has an ORCID defined also have a name defined
+	$self->{repository}->run_trigger( EPrints::Const::EP_TRIGGER_VALIDATE_FIELD(),
+		field => $self,
+		dataobj => $object,
+		value => $value,
+		problems => \@problems,
+	);
+
 	return @problems;
 }
 


### PR DESCRIPTION
Some documentation would be useful to add - not sure whether this should be included in the code, or just added to the wiki.

An example usage would be:
```perl
$c->add_trigger( EPrints::Const::EP_TRIGGER_VALIDATE_FIELD, sub
{
	my( %args ) = @_;
	my( $repo, $field, $dataobj, $value, $problems ) = @args{qw( repository field dataobj value problems )};

	# check if this is the compound field (rather than e.g. creators_name or creators_orcid)
	return unless ( $field->name eq "creators" || $field->name eq "editors" );

	my $floating_orcid = 0;
	# $value here is the full compound field.
	for( @{ $value } )
	{
		# If the ORCID is set, but nothing has been entered for the name...
		if( defined $_->{orcid} && !defined $_->{name} )
		{
			$floating_orcid++;
		}
	}

	if( $floating_orcid )
	{
		my $fieldname = $repo->xml->create_element( "span", class=>"ep_problem_field:".$field->name );
		$fieldname->appendChild( $field->render_name( $repo ) );

		push @$problems, $repo->html_phrase( "validate:creators_editors:floating_orcid", fieldname => $fieldname );
	}
}, priority => 100 );
```

This would also need a phrase e.g.:
```xml
<epp:phrase id="validate:creators_editors:floating_orcid">In <epc:pin name="fieldname" />, an ORCID is present, but has no name defined for it.</epp:phrase>
```