### PR TITLE
Related to issue #506, if a plugin failed to create an EPrint, improve the error sent to the CRUD client.

### DIFF
--- a/perl_lib/EPrints/Apache/CRUD.pm
+++ b/perl_lib/EPrints/Apache/CRUD.pm
@@ -1804,7 +1804,7 @@ sub POST
 	}
 	else
 	{
-		if (undefined $items[0]){
+		if (!defined $items[0]){
 			return  $self->sword_error(
 				status => HTTP_BAD_REQUEST,
 				summary => "Import plugin didn't create anything.  Check ".$repo->config( 'perl_url' )."/schema to ensure the metadata being sent is valid.",

--- a/perl_lib/EPrints/Apache/CRUD.pm
+++ b/perl_lib/EPrints/Apache/CRUD.pm
@@ -1804,6 +1804,12 @@ sub POST
 	}
 	else
 	{
+		if (undefined $items[0]){
+			return  $self->sword_error(
+				status => HTTP_BAD_REQUEST,
+				summary => "Import plugin didn't create anything.  Check ".$repo->config( 'perl_url' )."/schema to ensure the metadata being sent is valid.",
+			);
+		}
 		$r->err_headers_out->{Location} = $items[0]->uri;
 # DEBUG CODE
 if( defined $field && $headers->{mime_type} ne "application/atom+xml" )


### PR DESCRIPTION
Previously it would just be an HTTP 500 when $items[0] was undefined and "Can't call method "uri" on an undefined value at /opt/eprints3/perl_lib/EPrints/Apache/CRUD.pm".